### PR TITLE
Only enable TransactionScopeSuppressFeature if the transport selection if of the current endpoint matches the selected TransportType

### DIFF
--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -5,6 +5,7 @@
     using System.Text;
     using System.Threading.Tasks;
     using DelayedDelivery;
+    using Features;
     using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.ServiceBus.Primitives;
     using Performance.TimeToBeReceived;
@@ -40,6 +41,8 @@
             {
                 topicName = defaultTopicName;
             }
+
+            settings.EnableFeatureByDefault<TransactionScopeSuppressFeature>();
 
             namespacePermissions = new NamespacePermissions(connectionStringBuilder, tokenProvider);
 

--- a/src/Transport/Receiving/TransactionScopeSuppressFeature.cs
+++ b/src/Transport/Receiving/TransactionScopeSuppressFeature.cs
@@ -4,11 +4,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     class TransactionScopeSuppressFeature : Feature
     {
-        public TransactionScopeSuppressFeature()
-        {
-            EnableByDefault();
-        }
-
         protected override void Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register(new TransactionScopeSuppressBehavior.Registration());


### PR DESCRIPTION
Suppress behavior could interfere with other transports in multi-endpoint hosting scenarios