### PR TITLE
Do not auto-activate TransactionScopeSuppressFeature

### DIFF
--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -5,6 +5,7 @@
     using System.Text;
     using System.Threading.Tasks;
     using DelayedDelivery;
+    using Features;
     using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.ServiceBus.Primitives;
     using Performance.TimeToBeReceived;
@@ -40,6 +41,8 @@
             {
                 topicName = defaultTopicName;
             }
+
+            settings.EnableFeatureByDefault<TransactionScopeSuppressFeature>();
 
             namespacePermissions = new NamespacePermissions(connectionStringBuilder, tokenProvider);
 

--- a/src/Transport/Receiving/TransactionScopeSuppressFeature.cs
+++ b/src/Transport/Receiving/TransactionScopeSuppressFeature.cs
@@ -4,11 +4,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     class TransactionScopeSuppressFeature : Feature
     {
-        public TransactionScopeSuppressFeature()
-        {
-            EnableByDefault();
-        }
-
         protected override void Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register(new TransactionScopeSuppressBehavior.Registration());


### PR DESCRIPTION
## Who's affected

Anyone using multi-endpoint host with Azure Service Bus .NET Standard transport and a transport supporing `TransactionScope` [transport transaction](https://docs.particular.net/transports/transactions).

## Symptoms

 Azure Service Bus .NET Standard transport suppresses transaction scope for all transports in multi-endpoint host.

---

Replaces PR #11 