### PR TITLE
Interlocked.Read numberOfExecutingReceives

### DIFF
--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -18,7 +18,7 @@
         readonly int overriddenPrefetchCount;
         readonly TimeSpan timeToWaitBeforeTriggeringCircuitBreaker;
         readonly ITokenProvider tokenProvider;
-        int numberOfExecutingReceives;
+        long numberOfExecutingReceives;
 
         // Init
         Func<MessageContext, Task> onMessage;
@@ -275,7 +275,7 @@
 
             await receiveLoopTask.ConfigureAwait(false);
 
-            while (semaphore.CurrentCount + numberOfExecutingReceives != maxConcurrency)
+            while (semaphore.CurrentCount + Interlocked.Read(ref numberOfExecutingReceives) != maxConcurrency)
             {
                 await Task.Delay(50).ConfigureAwait(false);
             }


### PR DESCRIPTION
@tmasternak and I have been trying to hunt down an issue with ServiceControl AcceptanceTests and stumbled over the shutdown read of `numberOfExecutingReceives`. It would not hurt to properly read it with Interlocked since the value is increased and decremented. 