### PR TITLE
Null body

### DIFF
--- a/src/Tests/Receiving/MessageExtensionsTests.cs
+++ b/src/Tests/Receiving/MessageExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
+{
+    using System;
+    using Configuration;
+    using Microsoft.Azure.ServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MessageExtensionsTests
+    {
+        [Test]
+        public void Should_process_message_without_body()
+        {
+            var message = new Message();
+
+            var body = message.GetBody();
+            Assert.AreEqual(Array.Empty<byte>(), body);
+        }
+
+        [Test]
+        public void Should_process_byte_array_message_without_body()
+        {
+            var message = new Message();
+            message.UserProperties[TransportMessageHeaders.TransportEncoding] = "wcf/byte-array";
+
+            var body = message.GetBody();
+            Assert.AreEqual(Array.Empty<byte>(), body);
+        }
+    }
+}

--- a/src/Transport/Receiving/MessageExtensions.cs
+++ b/src/Transport/Receiving/MessageExtensions.cs
@@ -46,7 +46,7 @@
         {
             if (message.UserProperties.TryGetValue(TransportMessageHeaders.TransportEncoding, out var value) && value.Equals("wcf/byte-array"))
             {
-                return message.GetBody<byte[]>();
+                return message.GetBody<byte[]>() ?? Array.Empty<byte>();
             }
 
             return message.Body ?? Array.Empty<byte>();


### PR DESCRIPTION
Return empty `byte[]` when a native message has no body.