### PR TITLE
Allow PrefetchCount to be set to zero

### DIFF
--- a/src/Transport/Configuration/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/Configuration/AzureServiceBusTransportSettingsExtensions.cs
@@ -78,7 +78,7 @@
         }
 
         /// <summary>
-        /// Overrides the default time to wait before triggering a circuit breaker that initiates the endpoint shutdown procedure when the message pump cannot successfully receieve a message.
+        /// Overrides the default time to wait before triggering a circuit breaker that initiates the endpoint shutdown procedure when the message pump cannot successfully receive a message.
         /// </summary>
         /// <param name="transportExtensions"></param>
         /// <param name="timeToWait">The time to wait before triggering the circuit breaker.</param>

--- a/src/Transport/Configuration/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/Configuration/AzureServiceBusTransportSettingsExtensions.cs
@@ -70,7 +70,7 @@
         /// <param name="prefetchCount">The prefetch count to use.</param>
         public static TransportExtensions<AzureServiceBusTransport> PrefetchCount(this TransportExtensions<AzureServiceBusTransport> transportExtensions, int prefetchCount)
         {
-            Guard.AgainstNegativeAndZero(nameof(prefetchCount), prefetchCount);
+            Guard.AgainstNegative(nameof(prefetchCount), prefetchCount);
 
             transportExtensions.GetSettings().Set(SettingsKeys.PrefetchCount, prefetchCount);
 


### PR DESCRIPTION
Fixes #49 

Zero is the default value for ASB client.
NServiceBus transport sets the value to zero if user does not specify anything, but does not allow configuring prefetch count to zero using the API.

This PR fixes the API to accept zero as a valid value.