### PR TITLE
Bump SDK to latest

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="[4.0.0, 5.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.1, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="All" />

--- a/src/Transport/Sending/MessageSenderPool.cs
+++ b/src/Transport/Sending/MessageSenderPool.cs
@@ -53,16 +53,7 @@
 
             var connectionToUse = sender.OwnsConnection ? null : sender.ServiceBusConnection;
 
-            // TODO: remove workaround for ASB client bug when https://github.com/Azure/azure-service-bus-dotnet/issues/569 is fixed
-            var path = sender.Path;
-            var transferDestinationPath = sender.TransferDestinationPath;
-            if (!sender.OwnsConnection)
-            {
-                path = sender.TransferDestinationPath;
-                transferDestinationPath = sender.Path;
-            }
-
-            if (senders.TryGetValue((/*sender.Path*/path, (connectionToUse, /*sender.TransferDestinationPath*/transferDestinationPath)), out var sendersForDestination))
+            if (senders.TryGetValue((sender.Path, (connectionToUse, sender.TransferDestinationPath)), out var sendersForDestination))
             {
                 sendersForDestination.Enqueue(sender);
             }

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Just curious what breaks

**Update**
- Updated to new major 4.0.0
- Updated to new minor 4.1.0 with bug fixes
- Updated to new patch 4.1.1 with bug fixes