### PR TITLE
[SPIKE] Propogate LockedUntiUtc

### DIFF
--- a/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTests;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NUnit.Framework;
+
+public class When_receiving_a_message : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_have_a_header_to_indicate_when_lock_will_be_lost()
+    {
+        await Scenario.Define<Context>()
+            .WithEndpoint<Endpoint>(b => b.When(
+                (session, c) => session.SendLocal(new Message
+                {
+                    Property = "value"
+                })))
+            .Done(c => c.LockedUntilUtcHeaderFound)
+            .Run();
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool LockedUntilUtcHeaderFound { get; set; }
+    }
+
+    public class Endpoint : EndpointConfigurationBuilder
+    {
+        public Endpoint()
+        {
+            EndpointSetup<DefaultServer>();
+        }
+
+        public class Handler : IHandleMessages<Message>
+        {
+            public Context TestContext { get; set; }
+
+            public Task Handle(Message request, IMessageHandlerContext context)
+            {
+                TestContext.LockedUntilUtcHeaderFound = DateTime.TryParseExact(context.MessageHeaders["ASB.System.LockedUntilUtc"], "yyyy-MM-dd HH:mm:ss:ffffff Z", null, DateTimeStyles.None, out _);
+
+                return Task.FromResult(0);
+            }
+        }
+    }
+
+    public class Message : IMessage
+    {
+        public string Property { get; set; }
+    }
+}

--- a/src/Transport/Receiving/MessageExtensions.cs
+++ b/src/Transport/Receiving/MessageExtensions.cs
@@ -8,7 +8,7 @@
 
     static class MessageExtensions
     {
-        public static Dictionary<string, string> GetNServiceBusHeaders(this Message message)
+        public static Dictionary<string, string> GetRequiredHeaders(this Message message)
         {
             var headers = new Dictionary<string, string>(message.UserProperties.Count);
 
@@ -28,6 +28,8 @@
             {
                 headers[Headers.CorrelationId] = message.CorrelationId;
             }
+
+            headers["ASB.System.LockedUntilUtc"] = message.SystemProperties.LockedUntilUtc.ToString(dateTimeFormat);
 
             return headers;
         }
@@ -51,5 +53,7 @@
 
             return message.Body ?? Array.Empty<byte>();
         }
+
+        const string dateTimeFormat = "yyyy-MM-dd HH:mm:ss:ffffff Z";
     }
 }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -180,7 +180,7 @@
             try
             {
                 messageId = message.GetMessageId();
-                headers = message.GetNServiceBusHeaders();
+                headers = message.GetRequiredHeaders();
                 body = message.GetBody();
             }
             catch (Exception exception)
@@ -233,7 +233,7 @@
                     {
                         var transportTransaction = CreateTransportTransaction(message.PartitionKey);
 
-                        var errorContext = new ErrorContext(exception, message.GetNServiceBusHeaders(), messageId, body, transportTransaction, message.SystemProperties.DeliveryCount);
+                        var errorContext = new ErrorContext(exception, message.GetRequiredHeaders(), messageId, body, transportTransaction, message.SystemProperties.DeliveryCount);
 
                         result = await onError(errorContext).ConfigureAwait(false);
 


### PR DESCRIPTION
The idea is to allow the cancellation of an incoming message that cannot be processed due to expired lock.
Message processing can be cancelled using a custom behaviour and `TransportReceiveContext.AbortReceiveOperation` API.