### PR TITLE
Expose native Message

### DIFF
--- a/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
@@ -29,7 +29,8 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.Pipeline.Register(b => new CheckContextForValidUntilUtc(b.Build<Context>()), "Behavior to validate context bag contains the original brokered message"));
+                EndpointSetup<DefaultServer>((c, d) =>
+                    c.Pipeline.Register(b => new CheckContextForValidUntilUtc(d.ScenarioContext as Context), "Behavior to validate context bag contains the original brokered message"));
             }
 
             public class Handler : IHandleMessages<Message>

--- a/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
@@ -57,7 +57,7 @@
                 {
                     testContext.LockedUntilUtcFromBehavior = context.Extensions.Get<DateTime>(LockedUntilUtcKey);
 
-                    return Task.CompletedTask;
+                    return next();
                 }
             }
 

--- a/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Sending.Receiving
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_receiving_a_message
+    {
+        [Test]
+        public async Task Should_have_lock_expiration_in_the_context_bag()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When(
+                    (session, c) => session.SendLocal(new Message
+                    {
+                        Property = "value"
+                    })))
+                .Done(c => c.LockedUntilUtcHeaderFound)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool LockedUntilUtcHeaderFound { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Handler : IHandleMessages<Message>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(Message request, IMessageHandlerContext context)
+                {
+                    TestContext.LockedUntilUtcHeaderFound = context.Extensions.TryGet<DateTime>("Message.SystemProperties.LockedUntilUtc", out _);
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Message : IMessage
+        {
+            public string Property { get; set; }
+        }
+    }
+}

--- a/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
@@ -10,7 +10,7 @@
     public class When_receiving_a_message
     {
         [Test]
-        public async Task Should_have_access_to_brokered_message_system_properties_via_the_context_bag()
+        public async Task Should_have_access_to_the_original_brokered_message_via_the_context_bag()
         {
             await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When(
@@ -29,7 +29,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.Pipeline.Register(b => new CheckContextForValidUntilUtc(b.Build<Context>()), "Behavior to validate context bag contains brokered message system properties"));
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register(b => new CheckContextForValidUntilUtc(b.Build<Context>()), "Behavior to validate context bag contains the original brokered message"));
             }
 
             public class Handler : IHandleMessages<Message>
@@ -38,7 +38,7 @@
 
                 public Task Handle(Message request, IMessageHandlerContext context)
                 {
-                    TestContext.LockedUntilUtcFromHandler = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message.SystemPropertiesCollection>().LockedUntilUtc;
+                    TestContext.LockedUntilUtcFromHandler = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message>().SystemProperties.LockedUntilUtc;
 
                     return Task.CompletedTask;
                 }
@@ -55,7 +55,7 @@
 
                 public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
                 {
-                    testContext.LockedUntilUtcFromBehavior = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message.SystemPropertiesCollection>().LockedUntilUtc;
+                    testContext.LockedUntilUtcFromBehavior = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message>().SystemProperties.LockedUntilUtc;
 
                     return next();
                 }

--- a/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_message.cs
@@ -10,7 +10,7 @@
     public class When_receiving_a_message
     {
         [Test]
-        public async Task Should_have_lock_expiration_in_the_context_bag()
+        public async Task Should_have_access_to_brokered_message_system_properties_via_the_context_bag()
         {
             await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When(
@@ -29,7 +29,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.Pipeline.Register(b => new CheckContextForValidUntilUtc(b.Build<Context>()), "Behavior to validate context bag contains ValidUntilUtc value"));
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register(b => new CheckContextForValidUntilUtc(b.Build<Context>()), "Behavior to validate context bag contains brokered message system properties"));
             }
 
             public class Handler : IHandleMessages<Message>
@@ -38,7 +38,7 @@
 
                 public Task Handle(Message request, IMessageHandlerContext context)
                 {
-                    TestContext.LockedUntilUtcFromHandler = context.Extensions.Get<DateTime>(LockedUntilUtcKey);
+                    TestContext.LockedUntilUtcFromHandler = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message.SystemPropertiesCollection>().LockedUntilUtc;
 
                     return Task.CompletedTask;
                 }
@@ -55,13 +55,11 @@
 
                 public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
                 {
-                    testContext.LockedUntilUtcFromBehavior = context.Extensions.Get<DateTime>(LockedUntilUtcKey);
+                    testContext.LockedUntilUtcFromBehavior = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message.SystemPropertiesCollection>().LockedUntilUtc;
 
                     return next();
                 }
             }
-
-            const string LockedUntilUtcKey = "Message.SystemProperties.LockedUntilUtc";
         }
 
         public class Message : IMessage {}

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -204,7 +204,7 @@
                     var transportTransaction = CreateTransportTransaction(message.PartitionKey);
 
                     var contextBag = new ContextBag();
-                    contextBag.Set(message.SystemProperties);
+                    contextBag.Set(message);
 
                     var messageContext = new MessageContext(messageId, headers, body, transportTransaction, receiveCancellationTokenSource, contextBag);
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -204,7 +204,7 @@
                     var transportTransaction = CreateTransportTransaction(message.PartitionKey);
 
                     var contextBag = new ContextBag();
-                    contextBag.Set("Message.SystemProperties.LockedUntilUtc", message.SystemProperties.LockedUntilUtc);
+                    contextBag.Set(message.SystemProperties);
 
                     var messageContext = new MessageContext(messageId, headers, body, transportTransaction, receiveCancellationTokenSource, contextBag);
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -203,7 +203,10 @@
                 {
                     var transportTransaction = CreateTransportTransaction(message.PartitionKey);
 
-                    var messageContext = new MessageContext(messageId, headers, body, transportTransaction, receiveCancellationTokenSource, new ContextBag());
+                    var contextBag = new ContextBag();
+                    contextBag.Set("Message.SystemProperties.LockedUntilUtc", message.SystemProperties.LockedUntilUtc);
+
+                    var messageContext = new MessageContext(messageId, headers, body, transportTransaction, receiveCancellationTokenSource, contextBag);
 
                     using (var scope = CreateTransactionScope())
                     {


### PR DESCRIPTION
_Fixes #86_

_Replaces https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/85_

Propagate `Microsoft.Azure.ServiceBus.Message` via message's `ContextBag` to provide the information set by the broker per message.

An example is to allow the cancellation of an incoming message that cannot be processed due to expired lock. The system property, `LockedUntilUtc` could help to decide wherever a message should be attempted for processing or not in case it spent time longer than `MaxLockDuration` while in prefetch. 

With this change, the decision wherever a message should or should not be processed can be made at any point where context is available. E.g. a custom behaviour and `TransportReceiveContext.AbortReceiveOperation()` API, message handler, etc.