### PR TITLE
Add support for custom retry policy

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -9,6 +9,7 @@ namespace NServiceBus
     }
     public class static AzureServiceBusTransportSettingsExtensions
     {
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> CustomRetryPolicy(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> CustomTokenProvider(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, Microsoft.Azure.ServiceBus.Primitives.ITokenProvider tokenProvider) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> EnablePartitioning(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> EntityMaximumSize(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int maximumSizeInGB) { }

--- a/src/Tests/Sending/MessageSenderPoolTests.cs
+++ b/src/Tests/Sending/MessageSenderPoolTests.cs
@@ -10,7 +10,7 @@
         [Test]
         public async Task Should_get_cached_sender_per_destination()
         {
-            var pool = new MessageSenderPool(new ServiceBusConnectionStringBuilder(connectionString), null);
+            var pool = new MessageSenderPool(new ServiceBusConnectionStringBuilder(connectionString), null, null);
 
             try
             {
@@ -37,7 +37,7 @@
         [Test]
         public async Task Should_return_correctly_configured_sender()
         {
-            var pool = new MessageSenderPool(new ServiceBusConnectionStringBuilder(connectionString), null);
+            var pool = new MessageSenderPool(new ServiceBusConnectionStringBuilder(connectionString), null, null);
             var connection = new ServiceBusConnection(connectionString);
 
             try
@@ -66,7 +66,7 @@
         [Test]
         public async Task Should_get_cached_sender_per_destination_for_send_via()
         {
-            var pool = new MessageSenderPool(new ServiceBusConnectionStringBuilder(connectionString), null);
+            var pool = new MessageSenderPool(new ServiceBusConnectionStringBuilder(connectionString), null, null);
             var connection = new ServiceBusConnection(connectionString);
 
             try

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -88,7 +88,9 @@
                 timeToWaitBeforeTriggeringCircuitBreaker = TimeSpan.FromMinutes(2);
             }
 
-            return new MessagePump(connectionStringBuilder, tokenProvider, prefetchMultiplier, prefetchCount, timeToWaitBeforeTriggeringCircuitBreaker);
+            settings.TryGet(SettingsKeys.CustomRetryPolicy, out RetryPolicy retryPolicy);
+
+            return new MessagePump(connectionStringBuilder, tokenProvider, prefetchMultiplier, prefetchCount, timeToWaitBeforeTriggeringCircuitBreaker, retryPolicy);
         }
 
         QueueCreator CreateQueueCreator()
@@ -129,7 +131,9 @@
 
         MessageDispatcher CreateMessageDispatcher()
         {
-            messageSenderPool = new MessageSenderPool(connectionStringBuilder, tokenProvider);
+            settings.TryGet(SettingsKeys.CustomRetryPolicy, out RetryPolicy retryPolicy);
+
+            messageSenderPool = new MessageSenderPool(connectionStringBuilder, tokenProvider, retryPolicy);
 
             return new MessageDispatcher(messageSenderPool, topicName);
         }

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -62,7 +62,8 @@
                 PrefetchCount = settings.TryGet(SettingsKeys.PrefetchCount, out int? prefetchCount) ? prefetchCount.ToString() : "default",
                 UseWebSockets = settings.TryGet(SettingsKeys.TransportType, out TransportType _) ? "True" : "default",
                 TimeToWaitBeforeTriggeringCircuitBreaker = settings.TryGet(SettingsKeys.TransportType, out TimeSpan timeToWait) ? timeToWait.ToString() : "default",
-                CustomTokenProvider = settings.TryGet(SettingsKeys.CustomTokenProvider, out ITokenProvider customTokenProvider) ? customTokenProvider.ToString() : "default"
+                CustomTokenProvider = settings.TryGet(SettingsKeys.CustomTokenProvider, out ITokenProvider customTokenProvider) ? customTokenProvider.ToString() : "default",
+                CustomRetryPolicy = settings.TryGet(SettingsKeys.CustomRetryPolicy, out RetryPolicy customRetryPolicy) ? customRetryPolicy.ToString() : "default"
             });
         }
 

--- a/src/Transport/Configuration/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/Configuration/AzureServiceBusTransportSettingsExtensions.cs
@@ -167,5 +167,19 @@
 
             return transportExtensions;
         }
+
+        /// <summary>
+        /// Overrides the default retry policy with a custom implementation.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        /// <param name="retryPolicy">A custom retry policy to be used.</param>
+        public static TransportExtensions<AzureServiceBusTransport> CustomRetryPolicy(this TransportExtensions<AzureServiceBusTransport> transportExtensions, RetryPolicy retryPolicy)
+        {
+            Guard.AgainstNull(nameof(retryPolicy), retryPolicy);
+
+            transportExtensions.GetSettings().Set(SettingsKeys.CustomRetryPolicy, retryPolicy);
+
+            return transportExtensions;
+        }
     }
 }

--- a/src/Transport/Configuration/SettingsKeys.cs
+++ b/src/Transport/Configuration/SettingsKeys.cs
@@ -13,5 +13,6 @@
         public const string RuleNameShortener = Base + nameof(RuleNameShortener);
         public const string TransportType = Base + nameof(TransportType);
         public const string CustomTokenProvider = Base + nameof(CustomTokenProvider);
+        public const string CustomRetryPolicy = Base + nameof(CustomRetryPolicy);
     }
 }


### PR DESCRIPTION
Add support for custom retry policy via configuration API.

This adds a capability that was also available with the legacy ASB transport, [overriding RetryPolicy](https://docs.particular.net/transports/azure-service-bus/legacy/configuration/full#controlling-connectivity-messaging-factories) via configuration API.