### PR TITLE
Remove Custom.Build.props

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Target Name="SuppressNuGetPathLengthWarning" AfterTargets="GetVersion" BeforeTargets="CoreCompile" Condition="'$(TEAMCITY_VERSION)' != ''">
-    <PropertyGroup Condition="'$(GitVersion_BranchName)' != 'master' And $(GitVersion_BranchName.StartsWith('release-')) == false">
-      <NoWarn>$(NoWarn);NU5123</NoWarn>
-    </PropertyGroup>
-  </Target>
-
-</Project>


### PR DESCRIPTION
The target is no longer needed now that it's been added to Particular.Packaging, and since there's nothing else in the file, I've removed it entirely.