### PR TITLE
Switch to IBehavior because for internal things it is better in terms of allocations

### DIFF
--- a/src/Transport/Receiving/TransactionScopeSuppressBehavior.cs
+++ b/src/Transport/Receiving/TransactionScopeSuppressBehavior.cs
@@ -5,22 +5,22 @@ namespace NServiceBus.Transport.AzureServiceBus
     using System.Transactions;
     using Pipeline;
 
-    class TransactionScopeSuppressBehavior : Behavior<IIncomingPhysicalMessageContext>
+    class TransactionScopeSuppressBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
     {
-        public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
+        public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
             if (Transaction.Current != null)
             {
                 using (var tx = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await next().ConfigureAwait(false);
+                    await next(context).ConfigureAwait(false);
 
                     tx.Complete();
                 }
             }
             else
             {
-                await next().ConfigureAwait(false);
+                await next(context).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
See https://github.com/Particular/NServiceBus/pull/4125

- `Behavior<TContext>`is no longer used. Internal behaviors directly implement `IBehavior<TIn, TOut>`which saves a display class allocation and a function delegate allocation

```
    public Task Invoke(TContext context, Func<TContext, Task> next)
    {
      Behavior<TContext>.\u003C\u003Ec__DisplayClass0_0 cDisplayClass00 = new Behavior<TContext>.\u003C\u003Ec__DisplayClass0_0();
      cDisplayClass00.next = next;
      cDisplayClass00.context = context;
      Guard.AgainstNull(nameof (context), (object) cDisplayClass00.context);
      Guard.AgainstNull(nameof (next), (object) cDisplayClass00.next);
      // ISSUE: method pointer
      return this.Invoke(cDisplayClass00.context, new Func<Task>((object) cDisplayClass00, __methodptr(\u003CInvoke\u003Eb__0)));
    }
```