### PR TITLE
Support for Microsoft.Azure.ServiceBus 5.0 version range

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
     <PackageReference Include="Particular.Packaging" Version="0.6.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/CommandLineTests/NServiceBus.Transport.AzureServiceBus.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transport.AzureServiceBus.CommandLine.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup Label="Required to force the main project's transitive dependencies to be copied">
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="[5.0.0, 6.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.1, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.6.2" PrivateAssets="All" />

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Force the latest version of the transitive dependencies">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/195 to `release-1.5`