### PR TITLE
Allow outgoing message customizations

### DIFF
--- a/src/AcceptanceTests/Receiving/When_customizing_an_outgoing_native_message.cs
+++ b/src/AcceptanceTests/Receiving/When_customizing_an_outgoing_native_message.cs
@@ -1,0 +1,133 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Sending.Receiving
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+
+    public class When_customizing_an_outgoing_native_message
+    {
+        [Test]
+        public async Task Should_dispatch_native_message_with_the_customizations()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When(async (session, c) =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.RouteToThisEndpoint();
+                        sendOptions.CustomizeNativeMessage(m => m.Label = "IMessageSession.Send");
+                        await session.Send(new MessageSessionSentCommand(), sendOptions);
+
+                        var publishOptions = new PublishOptions();
+                        publishOptions.CustomizeNativeMessage(m => m.Label = "IMessageSession.Publish");
+                        await session.Publish(new MessageSessionPublishedEvent(), publishOptions);
+                    }))
+                .Done(c => c.Completed)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageSessionSentMessageCustomizationReceived { get; set; }
+            public bool MessageSessionPublishedMessageCustomizationReceived { get; set; }
+            public bool MessageHandlerContextSentMessageCustomizationReceived { get; set; }
+            public bool MessageHandlerContextPublishedMessageCustomizationReceived { get; set; }
+
+            public bool Completed => MessageSessionSentMessageCustomizationReceived
+                                     && MessageSessionPublishedMessageCustomizationReceived
+                                     && MessageHandlerContextSentMessageCustomizationReceived
+                                     && MessageHandlerContextPublishedMessageCustomizationReceived;
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+                // EndpointSetup<DefaultServer>((c, d) =>
+                //     c.Pipeline.Register(b => new ValidateIncomingNativeMessages((Context)d.ScenarioContext), "Behavior to validate the native messages contain customizations assigned when those native messages were dispatched"));
+            }
+
+            public class Handler :
+                IHandleMessages<MessageSessionSentCommand>,
+                IHandleMessages<MessageSessionPublishedEvent>,
+                IHandleMessages<MessageHandlerContextSentCommand>,
+                IHandleMessages<MessageHandlerContextPublishedEvent>
+            {
+                Context testContext;
+
+                public Handler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MessageSessionSentCommand request, IMessageHandlerContext context)
+                {
+                    var nativeMessage = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message>();
+
+                    testContext.MessageSessionSentMessageCustomizationReceived = nativeMessage.Label == "IMessageSession.Send";
+
+                    var sendOptions = new SendOptions();
+                    sendOptions.RouteToThisEndpoint();
+                    sendOptions.CustomizeNativeMessage(m => m.Label = "IMessageHandlerContext.Send");
+
+                    return context.Send(new MessageHandlerContextSentCommand(), sendOptions);
+                }
+
+                public Task Handle(MessageSessionPublishedEvent message, IMessageHandlerContext context)
+                {
+                    var nativeMessage = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message>();
+
+                    testContext.MessageSessionPublishedMessageCustomizationReceived = nativeMessage.Label == "IMessageSession.Publish";
+
+                    var publishOptions = new PublishOptions();
+                    publishOptions.CustomizeNativeMessage(m => m.Label = "IMessageHandlerContext.Publish");
+
+                    return context.Publish(new MessageHandlerContextPublishedEvent(), publishOptions);
+                }
+
+                public Task Handle(MessageHandlerContextSentCommand message, IMessageHandlerContext context)
+                {
+                    var nativeMessage = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message>();
+
+                    testContext.MessageHandlerContextSentMessageCustomizationReceived = nativeMessage.Label == "IMessageHandlerContext.Send";
+
+                    return Task.CompletedTask;
+                }
+
+                public Task Handle(MessageHandlerContextPublishedEvent message, IMessageHandlerContext context)
+                {
+                    var nativeMessage = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message>();
+
+                    testContext.MessageHandlerContextPublishedMessageCustomizationReceived = nativeMessage.Label == "IMessageHandlerContext.Publish";
+
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class ValidateIncomingNativeMessages : Behavior<ITransportReceiveContext>
+            {
+                readonly Context testContext;
+
+                public ValidateIncomingNativeMessages(Context context)
+                {
+                    testContext = context;
+                }
+
+                public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+                {
+                    testContext.MessageSessionSentMessageCustomizationReceived = context.Extensions.Get<Microsoft.Azure.ServiceBus.Message>() != null;
+
+                    return next();
+                }
+            }
+        }
+
+        public class MessageSessionSentCommand : ICommand {}
+        public class MessageSessionPublishedEvent : IEvent {}
+        public class MessageHandlerContextSentCommand : ICommand { }
+        public class MessageHandlerContextPublishedEvent : IEvent { }
+    }
+}

--- a/src/AcceptanceTests/Sending/When_customizing_an_outgoing_native_message.cs
+++ b/src/AcceptanceTests/Sending/When_customizing_an_outgoing_native_message.cs
@@ -69,7 +69,7 @@
 
                     var sendOptions = new SendOptions();
                     sendOptions.RouteToThisEndpoint();
-                    sendOptions.CustomizeNativeMessage(m => m.Label = "IMessageHandlerContext.Send");
+                    sendOptions.CustomizeNativeMessage(context, m => m.Label = "IMessageHandlerContext.Send");
 
                     return context.Send(new MessageHandlerContextSentCommand(), sendOptions);
                 }
@@ -81,7 +81,7 @@
                     testContext.MessageSessionPublishedMessageCustomizationReceived = nativeMessage.Label == "IMessageSession.Publish";
 
                     var publishOptions = new PublishOptions();
-                    publishOptions.CustomizeNativeMessage(m => m.Label = "IMessageHandlerContext.Publish");
+                    publishOptions.CustomizeNativeMessage(context, m => m.Label = "IMessageHandlerContext.Publish");
 
                     return context.Publish(new MessageHandlerContextPublishedEvent(), publishOptions);
                 }

--- a/src/AcceptanceTests/Sending/When_customizing_an_outgoing_native_message.cs
+++ b/src/AcceptanceTests/Sending/When_customizing_an_outgoing_native_message.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Sending.Receiving
+﻿namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Sending
 {
     using System;
     using System.Threading.Tasks;
@@ -46,8 +46,6 @@
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>();
-                // EndpointSetup<DefaultServer>((c, d) =>
-                //     c.Pipeline.Register(b => new ValidateIncomingNativeMessages((Context)d.ScenarioContext), "Behavior to validate the native messages contain customizations assigned when those native messages were dispatched"));
             }
 
             public class Handler :

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -24,5 +24,6 @@ namespace NServiceBus
     public class static CustomizeNativeMessageExtensions
     {
         public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
+        public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, NServiceBus.IMessageHandlerContext context, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
     }
 }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -24,6 +24,6 @@ namespace NServiceBus
     public class static CustomizeNativeMessageExtensions
     {
         public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
-        public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, NServiceBus.IMessageHandlerContext context, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
+        public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, NServiceBus.IPipelineContext context, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
     }
 }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -21,4 +21,8 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> TopicName(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string topicName) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> UseWebSockets(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
     }
+    public class static CustomizeNativeMessageExtensions
+    {
+        public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
+    }
 }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -209,6 +209,7 @@
 
                     var contextBag = new ContextBag();
                     contextBag.Set(message);
+                    contextBag.GetOrCreate<NativeMessageCustomizer>();
 
                     var messageContext = new MessageContext(messageId, headers, body, transportTransaction,
                         receiveCancellationTokenSource, contextBag);

--- a/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
+++ b/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
@@ -37,10 +37,13 @@
         }
 
         /// <summary>
-        /// Allows customization of the outgoing native message sent using <see cref="IMessageHandlerContext"/>.
+        /// Allows customization of the outgoing native message.
         /// </summary>
+        /// <remarks>
+        /// Messages can be sent using <see cref="IPipelineContext"/> or any of its derived variants such as <see cref="IMessageHandlerContext"/>.
+        /// </remarks>
         /// <param name="options">Option being extended.</param>
-        /// <param name="context"><see cref="IMessageHandlerContext"/> used to dispatch messages in the message handler.</param>
+        /// <param name="context">Context used to dispatch messages in the message handler.</param>
         /// <param name="customization">Customization action.</param>
         public static void CustomizeNativeMessage(this ExtendableOptions options, IPipelineContext context, Action<Message> customization)
         {

--- a/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
+++ b/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
@@ -42,7 +42,7 @@
         /// <param name="options">Option being extended.</param>
         /// <param name="context"><see cref="IMessageHandlerContext"/> used to dispatch messages in the message handler.</param>
         /// <param name="customization">Customization action.</param>
-        public static void CustomizeNativeMessage(this ExtendableOptions options, IMessageHandlerContext context, Action<Message> customization)
+        public static void CustomizeNativeMessage(this ExtendableOptions options, IPipelineContext context, Action<Message> customization)
         {
             if (options.GetHeaders().ContainsKey(CustomizationHeader))
             {

--- a/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
+++ b/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Concurrent;
-
-namespace NServiceBus
+﻿namespace NServiceBus
 {
     using System;
     using Microsoft.Azure.ServiceBus;
@@ -32,17 +30,10 @@ namespace NServiceBus
             options.SetHeader(CustomizationHeader, customizationId);
 
             var nativePropertiesCustomizer = options.GetExtensions().GetOrCreate<NativeMessageCustomizer>();
-            nativePropertiesCustomizer.Customizations = nativePropertiesCustomizer.Customizations ?? new ConcurrentDictionary<string, Action<Message>>();
-
             if (!nativePropertiesCustomizer.Customizations.TryAdd(customizationId, customization))
             {
                 throw new Exception("Failed to apply an outgoing message customization");
             }
-        }
-
-        internal class NativeMessageCustomizer
-        {
-            public ConcurrentDictionary<string, Action<Message>> Customizations;
         }
     }
 }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -96,11 +96,11 @@
             return tasks.Count == 1 ? tasks[0] : Task.WhenAll(tasks);
         }
 
-        private static void ApplyCustomizationToOutgoingNativeMessage(ContextBag context, IOutgoingTransportOperation transportOperation, Message message)
+        private static void ApplyCustomizationToOutgoingNativeMessage(ReadOnlyContextBag context, IOutgoingTransportOperation transportOperation, Message message)
         {
             if (transportOperation.Message.Headers.TryGetValue(CustomizeNativeMessageExtensions.CustomizationHeader, out var customizationId))
             {
-                if (context.TryGet<CustomizeNativeMessageExtensions.NativeMessageCustomizer>(out var nmc) && nmc.Customizations.Keys.Contains(customizationId))
+                if (context.TryGet<NativeMessageCustomizer>(out var nmc) && nmc.Customizations.Keys.Contains(customizationId))
                 {
                     nmc.Customizations[customizationId].Invoke(message);
                 }

--- a/src/Transport/Sending/NativeMessageCustomizer.cs
+++ b/src/Transport/Sending/NativeMessageCustomizer.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections.Concurrent;
+    using Microsoft.Azure.ServiceBus;
+
+    internal class NativeMessageCustomizer
+    {
+        private ConcurrentDictionary<string, Action<Message>> customizations;
+
+        public ConcurrentDictionary<string, Action<Message>> Customizations => customizations ?? (customizations = new ConcurrentDictionary<string, Action<Message>>());
+    }
+}


### PR DESCRIPTION
Fixes #202 

Scenarios:
- [x] Send using `IMessageSession`
- [x] Publish using `IMessageSession`
- [x] Send using `IMessageHandlerContext`
- [x] Publish using `IMessageHandlerContext`
- [x] Expand support to `IPipelineContext` to allow customizations from behaviors (https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/203/commits/ae7b874f21fef1b2561e471c3c534ad77fc95204)