### PR TITLE
Obsolete CustomizeNativeMessage method

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -66,5 +66,9 @@ namespace NServiceBus
     public static class CustomizeNativeMessageExtensions
     {
         public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
+        [System.Obsolete("Use `CustomizeNativeMessage(this ExtendableOptions options, Action<Message> custo" +
+            "mization)` instead. The member currently throws a NotImplementedException. Will " +
+            "be removed in version 3.0.0.", true)]
+        public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, NServiceBus.IPipelineContext context, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
     }
 }

--- a/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
+++ b/src/Transport/Sending/CustomizeNativeMessageExtensions.cs
@@ -10,7 +10,7 @@
     /// <remarks>
     /// The behavior of this class is exposed via extension methods.
     /// </remarks>
-    public static class CustomizeNativeMessageExtensions
+    public static partial class CustomizeNativeMessageExtensions
     {
         /// <summary>
         /// Allows customization of the outgoing native message sent using <see cref="IMessageSession"/>.

--- a/src/Transport/obsoletes-v2.cs
+++ b/src/Transport/obsoletes-v2.cs
@@ -99,5 +99,22 @@ namespace NServiceBus
     }
 }
 
+namespace NServiceBus
+{
+    using System;
+    using Microsoft.Azure.ServiceBus;
+    using Extensibility;
+
+    public static partial class CustomizeNativeMessageExtensions
+    {
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "CustomizeNativeMessage(this ExtendableOptions options, Action<Message> customization)",
+            TreatAsErrorFromVersion = "2",
+            RemoveInVersion = "3")]
+        public static void CustomizeNativeMessage(this ExtendableOptions options, IPipelineContext context,
+            Action<Message> customization) => throw new NotImplementedException();
+    }
+}
+
 #pragma warning restore 1591
 #pragma warning restore 618


### PR DESCRIPTION
This overload was just removed instead of being properly obsoleted. Therefore this PR adds the overload back and adds an obsolete method.