### PR TITLE
Cache namespace permission check results

### DIFF
--- a/src/Transport/Administration/NamespacePermissions.cs
+++ b/src/Transport/Administration/NamespacePermissions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.ServiceBus.Management;
@@ -11,13 +12,19 @@
         readonly ServiceBusConnectionStringBuilder connectionStringBuilder;
         readonly ITokenProvider tokenProvider;
 
+        readonly Lazy<Task> manageCheck;
+
         public NamespacePermissions(ServiceBusConnectionStringBuilder connectionStringBuilder, ITokenProvider tokenProvider)
         {
             this.connectionStringBuilder = connectionStringBuilder;
             this.tokenProvider = tokenProvider;
+
+            manageCheck = new Lazy<Task>(() => CheckPermission(), LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
-        public async Task CanManage()
+        public Task CanManage() => manageCheck.Value;
+
+        async Task CheckPermission()
         {
             var client = new ManagementClient(connectionStringBuilder, tokenProvider);
 

--- a/src/Transport/Administration/SubscriptionManager.cs
+++ b/src/Transport/Administration/SubscriptionManager.cs
@@ -31,7 +31,7 @@
 
         public async Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context)
         {
-            await CheckForManagePermissions().ConfigureAwait(false);
+            await namespacePermissions.CanManage().ConfigureAwait(false);
             var client = new ManagementClient(connectionStringBuilder, transportSettings.TokenProvider);
 
             try
@@ -78,7 +78,7 @@
 
         public async Task Unsubscribe(MessageMetadata eventType, ContextBag context)
         {
-            await CheckForManagePermissions().ConfigureAwait(false);
+            await namespacePermissions.CanManage().ConfigureAwait(false);
 
             var ruleName = transportSettings.SubscriptionRuleNamingConvention(eventType.MessageType);
 
@@ -132,16 +132,5 @@
                 await client.CloseAsync().ConfigureAwait(false);
             }
         }
-
-        async Task CheckForManagePermissions()
-        {
-            if (!verifiedManagePermissions)
-            {
-                await namespacePermissions.CanManage().ConfigureAwait(false);
-                verifiedManagePermissions = true;
-            }
-        }
-
-        bool verifiedManagePermissions;
     }
 }


### PR DESCRIPTION
The transport calls `NamespacePermissions.CheckPermission()` multiple times, at startup and runtime (e.g. when creating queues, when creating the subscription, and when subscribing/unsubscribing). Given it's always the same check, it seems to be a lot more efficient to check this once and cache the result (what the subscription manager itself already did).

With this change, we can save some HTTP requests at startup time, improving startup performance.

I've used a `Lazy<Task>` for caching. I think it's not necessary to wrap the call in the factory in a `Task.Run` as usually seen in guidance for async-lazy types as this involves IO that is always going to be awaited directly, so fast returns from the factory method are not that important (there is also no parallelism involved at startup) and we can save the effort to unwrap and so on. Thoughts @danielmarbach ?