### PR TITLE
Skip throwing an exception when a queue already exists.

### DIFF
--- a/src/CommandLine/Endpoint.cs
+++ b/src/CommandLine/Endpoint.cs
@@ -16,7 +16,7 @@
             }
             catch (MessagingEntityAlreadyExistsException)
             {
-                Console.WriteLine($"Queue '{name}' already exists, skipping creation");
+                Console.WriteLine($"Queue '{name.Value}' already exists, skipping creation");
             }
 
             try
@@ -25,7 +25,7 @@
             }
             catch (MessagingEntityAlreadyExistsException)
             {
-                Console.WriteLine($"Topic '{topicName}' already exists, skipping creation");
+                Console.WriteLine($"Topic '{topicName.Value()}' already exists, skipping creation");
             }
 
             try
@@ -34,7 +34,7 @@
             }
             catch (MessagingEntityAlreadyExistsException)
             {
-                Console.WriteLine($"Subscription '{name}' already exists, skipping creation");
+                Console.WriteLine($"Subscription '{name.Value}' already exists, skipping creation");
             }
         }
 
@@ -46,7 +46,7 @@
             }
             catch (MessagingEntityAlreadyExistsException)
             {
-                Console.WriteLine($"Rule '{name}' for topic '{topicName}' and subscription '{subscriptionName}' already exists, skipping creation. Verify SQL filter matches '[NServiceBus.EnclosedMessageTypes] LIKE '%{eventType.Value}%'.");
+                Console.WriteLine($"Rule '{name}' for topic '{topicName.Value()}' and subscription '{subscriptionName.Value()}' already exists, skipping creation. Verify SQL filter matches '[NServiceBus.EnclosedMessageTypes] LIKE '%{eventType.Value}%'.");
             }
         }
 
@@ -58,7 +58,7 @@
             }
             catch (MessagingEntityNotFoundException)
             {
-                Console.WriteLine($"Rule '{name}' for topic '{topicName}' and subscription '{subscriptionName}' does not exist, skipping deletion");
+                Console.WriteLine($"Rule '{name}' for topic '{topicName.Value()}' and subscription '{subscriptionName.Value()}' does not exist, skipping deletion");
             }
         }
     }

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using McMaster.Extensions.CommandLineUtils;
+    using Microsoft.Azure.ServiceBus.Management;
 
     class Program
     {
@@ -116,9 +117,15 @@
 
                     createCommand.OnExecuteAsync(async ct =>
                     {
-                        await CommandRunner.Run(connectionString, client => Queue.Create(client, name, size, partitioning));
-
-                        Console.WriteLine($"Queue name '{name.Value}', size '{(size.HasValue() ? size.ParsedValue : 5)}GB', partitioned '{partitioning.HasValue()}' created");
+                        try
+                        {
+                            await CommandRunner.Run(connectionString, client => Queue.Create(client, name, size, partitioning));
+                            Console.WriteLine($"Queue name '{name.Value}', size '{(size.HasValue() ? size.ParsedValue : 5)}GB', partitioned '{partitioning.HasValue()}' created");
+                        }
+                        catch (MessagingEntityAlreadyExistsException)
+                        {
+                            Console.WriteLine($"Queue '{name.Value}' already exists, skipping creation");
+                        }
                     });
                 });
 

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -83,15 +83,16 @@
         }
 
         [Test]
-        public async Task Create_queue_when_it_exists_should_throw()
+        public async Task Create_queue_when_it_exists_should_skip()
         {
             await DeleteQueue(QueueName);
             await Execute($"queue create {QueueName}");
 
-            var (_, error, exitCode) = await Execute($"queue create {QueueName}");
+            var (output, error, exitCode) = await Execute($"queue create {QueueName}");
 
-            Assert.AreEqual(1, exitCode);
-            Assert.IsTrue(error.Contains(nameof(MessagingEntityAlreadyExistsException)));
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+            Assert.IsTrue(output.Contains("skipping"));
 
             await VerifyQueue(QueueName);
         }
@@ -237,17 +238,6 @@
             try
             {
                 await client.DeleteTopicAsync(topicName);
-            }
-            catch (MessagingEntityNotFoundException)
-            {
-            }
-        }
-
-        async Task DeleteSubscription(string topicName, string subscriptionName)
-        {
-            try
-            {
-                await client.DeleteSubscriptionAsync(topicName, subscriptionName);
             }
             catch (MessagingEntityNotFoundException)
             {


### PR DESCRIPTION
Closes https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/173.
* were fixed names in the output for some entities
before the change:
![was](https://user-images.githubusercontent.com/5980232/108498104-0d235b00-72b5-11eb-84d2-96c44259c788.png)
and after:
![image](https://user-images.githubusercontent.com/5980232/108498122-16acc300-72b5-11eb-9b66-ac4f853a5a8a.png)


