### PR TITLE
Implement testing helpers to get access to the customization

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -72,3 +72,10 @@ namespace NServiceBus
         public static void CustomizeNativeMessage(this NServiceBus.Extensibility.ExtendableOptions options, NServiceBus.IPipelineContext context, System.Action<Microsoft.Azure.ServiceBus.Message> customization) { }
     }
 }
+namespace NServiceBus.Testing
+{
+    public static class TestableCustomizeNativeMessageExtensions
+    {
+        public static System.Action<Microsoft.Azure.ServiceBus.Message> GetNativeMessageCustomization(this NServiceBus.Extensibility.ExtendableOptions options) { }
+    }
+}

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
+    <PackageReference Include="NServiceBus.Testing" Version="8.0.0-alpha.107" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />

--- a/src/Tests/Testing/TestableCustomizeNativeMessageExtensionsTests.cs
+++ b/src/Tests/Testing/TestableCustomizeNativeMessageExtensionsTests.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.Tests.Testing
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TestableCustomizeNativeMessageExtensionsTests
+    {
+        [Test]
+        public async Task GetNativeMessageCustomization_should_return_customization()
+        {
+            var testableContext = new TestableMessageHandlerContext();
+
+            var handler = new MyHandlerUsingCustomizations();
+
+            await handler.Handle(new MyMessage(), testableContext);
+
+            var publishedMessage = testableContext.PublishedMessages.Single();
+            var customization = publishedMessage.Options.GetNativeMessageCustomization();
+
+            var nativeMessage = new Message();
+            customization(nativeMessage);
+
+            Assert.AreEqual("abc", nativeMessage.Label);
+        }
+
+        [Test]
+        public async Task GetNativeMessageCustomization_when_no_customization_should_return_null()
+        {
+            var testableContext = new TestableMessageHandlerContext();
+
+            var handler = new MyHandlerWithoutCustomization();
+
+            await handler.Handle(new MyMessage(), testableContext);
+
+            var publishedMessage = testableContext.PublishedMessages.Single();
+            var customization = publishedMessage.Options.GetNativeMessageCustomization();
+
+            Assert.IsNull(customization);
+        }
+
+        class MyHandlerUsingCustomizations : IHandleMessages<MyMessage>
+        {
+            public async Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                var options = new PublishOptions();
+                options.CustomizeNativeMessage(m => m.Label = "abc");
+                await context.Publish(message, options);
+            }
+        }
+
+        class MyHandlerWithoutCustomization : IHandleMessages<MyMessage>
+        {
+            public async Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                var options = new PublishOptions();
+                await context.Publish(message, options);
+            }
+        }
+
+        class MyMessage
+        {
+        }
+    }
+
+
+}

--- a/src/Transport/Testing/TestableCustomizeNativeMessageExtensions.cs
+++ b/src/Transport/Testing/TestableCustomizeNativeMessageExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Testing
+{
+    using System;
+    using Extensibility;
+    using Microsoft.Azure.ServiceBus;
+
+    /// <summary>
+    /// Provides helper implementations for the native message customization for testing purposes.
+    /// </summary>
+    public static class TestableCustomizeNativeMessageExtensions
+    {
+        /// <summary>
+        /// Gets the customization of the outgoing native message sent using <see cref="NServiceBus.SendOptions"/>, <see cref="NServiceBus.PublishOptions"/> or <see cref="NServiceBus.ReplyOptions"/>.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        /// <returns>The customization action or null.</returns>
+        public static Action<Message> GetNativeMessageCustomization(this ExtendableOptions options)
+        {
+            return options.GetExtensions().TryGet<Action<Message>>(NativeMessageCustomizationBehavior.CustomizationKey, out var customization) ? customization : null;
+        }
+    }
+}


### PR DESCRIPTION
Addresses #218

Bringing these changes back to 1.9 requires a few changes to the code here since `master` behaves slightly different when it comes to storing the customizations