### PR TITLE
Add Core v7 shim configuration API

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -3,6 +3,15 @@ namespace NServiceBus
 {
     public class AzureServiceBusSettings : NServiceBus.TransportSettings<NServiceBus.AzureServiceBusTransport>
     {
+        [System.Obsolete("Setting connection string at the endpoint level is no longer supported. Transport" +
+            " specific configuration options should be used instead. The member currently thr" +
+            "ows a NotImplementedException. Will be removed in version 3.0.0.", true)]
+        public NServiceBus.AzureServiceBusSettings ConnectionString(System.Func<string> connectionString) { }
+        [System.Obsolete("Provide the connection string to the AzureServiceBusTransport constructor. Will b" +
+            "e treated as an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings ConnectionString(string connectionString) { }
+        [System.Obsolete(@"The ability to used named connection strings has been removed. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString). Use `TransportExtensions.ConnectionString(connectionString)` instead. The member currently throws a NotImplementedException. Will be removed in version 3.0.0.", true)]
+        public NServiceBus.AzureServiceBusSettings ConnectionStringName(string name) { }
         [System.Obsolete("Use `AzureServiceBusTransport.RetryPolicy` instead. Will be treated as an error f" +
             "rom version 3.0.0. Will be removed in version 4.0.0.", false)]
         public NServiceBus.AzureServiceBusSettings CustomRetryPolicy(Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
@@ -49,7 +58,7 @@ namespace NServiceBus
     {
         [System.Obsolete("Use `EndpointConfiguration.UseTransport(TransportDefinition)` instead. Will be tr" +
             "eated as an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
-        public static NServiceBus.AzureServiceBusSettings UseTransport<TTransport>(this NServiceBus.EndpointConfiguration endpointConfiguration, string connectionString)
+        public static NServiceBus.AzureServiceBusSettings UseTransport<TTransport>(this NServiceBus.EndpointConfiguration endpointConfiguration)
             where TTransport : NServiceBus.AzureServiceBusTransport { }
     }
     public class AzureServiceBusTransport : NServiceBus.Transport.TransportDefinition

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -21,11 +21,12 @@ namespace NServiceBus
         [System.Obsolete("Use `AzureServiceBusTransport.PrefetchMultiplier` instead. Will be treated as an " +
             "error from version 3.0.0. Will be removed in version 4.0.0.", false)]
         public NServiceBus.AzureServiceBusSettings PrefetchMultiplier(int prefetchMultiplier) { }
-        [System.Obsolete("Use `SubscriptionNamingConvention` instead. The member currently throws a NotImpl" +
-            "ementedException. Will be removed in version 3.0.0.", true)]
+        [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionRuleNamingConvention` instead. The memb" +
+            "er currently throws a NotImplementedException. Will be removed in version 3.0.0." +
+            "", true)]
         public NServiceBus.AzureServiceBusSettings RuleNameShortener(System.Func<string, string> ruleNameShortener) { }
-        [System.Obsolete("Use `SubscriptionNamingConvention` instead. The member currently throws a NotImpl" +
-            "ementedException. Will be removed in version 3.0.0.", true)]
+        [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionNamingConvention` instead. The member c" +
+            "urrently throws a NotImplementedException. Will be removed in version 3.0.0.", true)]
         public NServiceBus.AzureServiceBusSettings SubscriptionNameShortener(System.Func<string, string> subscriptionNameShortener) { }
         [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionNamingConvention` instead. Will be trea" +
             "ted as an error from version 3.0.0. Will be removed in version 4.0.0.", false)]

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,6 +1,56 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"NServiceBus.Transport.AzureServiceBus.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 namespace NServiceBus
 {
+    public class AzureServiceBusSettings : NServiceBus.TransportSettings<NServiceBus.AzureServiceBusTransport>
+    {
+        [System.Obsolete("Use `AzureServiceBusTransport.RetryPolicy` instead. Will be treated as an error f" +
+            "rom version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings CustomRetryPolicy(Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.TokenProvider` instead. Will be treated as an error" +
+            " from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings CustomTokenProvider(Microsoft.Azure.ServiceBus.Primitives.ITokenProvider tokenProvider) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.EnablePartitioning` instead. Will be treated as an " +
+            "error from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings EnablePartitioning() { }
+        [System.Obsolete("Use `AzureServiceBusTransport.EntityMaximumSize` instead. Will be treated as an e" +
+            "rror from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings EntityMaximumSize(int maximumSizeInGB) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.PrefetchCount` instead. Will be treated as an error" +
+            " from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings PrefetchCount(int prefetchCount) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.PrefetchMultiplier` instead. Will be treated as an " +
+            "error from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings PrefetchMultiplier(int prefetchMultiplier) { }
+        [System.Obsolete("Use `SubscriptionNamingConvention` instead. The member currently throws a NotImpl" +
+            "ementedException. Will be removed in version 3.0.0.", true)]
+        public NServiceBus.AzureServiceBusSettings RuleNameShortener(System.Func<string, string> ruleNameShortener) { }
+        [System.Obsolete("Use `SubscriptionNamingConvention` instead. The member currently throws a NotImpl" +
+            "ementedException. Will be removed in version 3.0.0.", true)]
+        public NServiceBus.AzureServiceBusSettings SubscriptionNameShortener(System.Func<string, string> subscriptionNameShortener) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionNamingConvention` instead. Will be trea" +
+            "ted as an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings SubscriptionNamingConvention(System.Func<string, string> subscriptionNamingConvention) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionRuleNamingConvention` instead. Will be " +
+            "treated as an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings SubscriptionRuleNamingConvention(System.Func<System.Type, string> subscriptionRuleNamingConvention) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.TimeToWaitBeforeTriggeringCircuitBreaker` instead. " +
+            "Will be treated as an error from version 3.0.0. Will be removed in version 4.0.0" +
+            ".", false)]
+        public NServiceBus.AzureServiceBusSettings TimeToWaitBeforeTriggeringCircuitBreaker(System.TimeSpan timeToWait) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.TopicName` instead. Will be treated as an error fro" +
+            "m version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings TopicName(string topicName) { }
+        [System.Obsolete("Use `AzureServiceBusTransport.UseWebSockets` instead. Will be treated as an error" +
+            " from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public NServiceBus.AzureServiceBusSettings UseWebSockets() { }
+    }
+    public static class AzureServiceBusSettingsExtensions
+    {
+        [System.Obsolete("Use `EndpointConfiguration.UseTransport(TransportDefinition)` instead. Will be tr" +
+            "eated as an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
+        public static NServiceBus.AzureServiceBusSettings UseTransport<TTransport>(this NServiceBus.EndpointConfiguration endpointConfiguration, string connectionString)
+            where TTransport : NServiceBus.AzureServiceBusTransport { }
+    }
     public class AzureServiceBusTransport : NServiceBus.Transport.TransportDefinition
     {
         public AzureServiceBusTransport(string connectionString) { }
@@ -39,11 +89,12 @@ namespace NServiceBus
         [System.Obsolete("Use `AzureServiceBusTransport.PrefetchMultiplier` instead. The member currently t" +
             "hrows a NotImplementedException. Will be removed in version 3.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> PrefetchMultiplier(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int prefetchMultiplier) { }
-        [System.Obsolete("Use `SubscriptionRuleNamingConvention` instead. The member currently throws a Not" +
-            "ImplementedException. Will be removed in version 3.0.0.", true)]
+        [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionRuleNamingConvention` instead. The memb" +
+            "er currently throws a NotImplementedException. Will be removed in version 3.0.0." +
+            "", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> RuleNameShortener(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.Func<string, string> ruleNameShortener) { }
-        [System.Obsolete("Use `SubscriptionNamingConvention` instead. The member currently throws a NotImpl" +
-            "ementedException. Will be removed in version 3.0.0.", true)]
+        [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionNamingConvention` instead. The member c" +
+            "urrently throws a NotImplementedException. Will be removed in version 3.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> SubscriptionNameShortener(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.Func<string, string> subscriptionNameShortener) { }
         [System.Obsolete("Use `AzureServiceBusTransport.SubscriptionNamingConvention` instead. The member c" +
             "urrently throws a NotImplementedException. Will be removed in version 3.0.0.", true)]
@@ -56,8 +107,8 @@ namespace NServiceBus
             "The member currently throws a NotImplementedException. Will be removed in versio" +
             "n 3.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> TimeToWaitBeforeTriggeringCircuitBreaker(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.TimeSpan timeToWait) { }
-        [System.Obsolete("Use `TransportDefinition.TopicName` instead. The member currently throws a NotImp" +
-            "lementedException. Will be removed in version 3.0.0.", true)]
+        [System.Obsolete("Use `AzureServiceBusTransport.TopicName` instead. The member currently throws a N" +
+            "otImplementedException. Will be removed in version 3.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> TopicName(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string topicName) { }
         [System.Obsolete("Use `AzureServiceBusTransport.UseWebSockets` instead. The member currently throws" +
             " a NotImplementedException. Will be removed in version 3.0.0.", true)]

--- a/src/Tests/MigrationApiTests.cs
+++ b/src/Tests/MigrationApiTests.cs
@@ -91,7 +91,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
                 new ReceiveSettings[0],
                 new string[0],
                 CancellationToken.None));
-            StringAssert.Contains("No transport connection string has been configured via the 'ConnectionString' method. Provide a connection string using endpointConfig.UseTransport<AzureServiceBusTransport>().ConnectionString(connectionString)", ex.Message);
+            StringAssert.Contains("No transport connection string has been configured via the 'ConnectionString' method. Provide a connection string using 'endpointConfig.UseTransport<AzureServiceBusTransport>().ConnectionString(connectionString)'.", ex.Message);
         }
     }
 }

--- a/src/Tests/MigrationApiTests.cs
+++ b/src/Tests/MigrationApiTests.cs
@@ -1,0 +1,81 @@
+﻿#pragma warning disable IDE0079 // Remove unnecessary suppression
+#pragma warning disable CS0618
+namespace NServiceBus.Transport.AzureServiceBus.Tests
+{
+    using System;
+    using Microsoft.Azure.ServiceBus;
+    using Microsoft.Azure.ServiceBus.Primitives;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MigrationApiTests
+    {
+        [Test]
+        public void UseTransport_should_configure_default_values()
+        {
+            var defaultSettings = new AzureServiceBusTransport("ConnectionString");
+            var endpointConfiguration = new EndpointConfiguration(nameof(MigrationApiTests));
+            endpointConfiguration.UseTransport<AzureServiceBusTransport>("ConnectionString");
+
+            var configuredTransport = (AzureServiceBusTransport)endpointConfiguration.GetSettings().Get<TransportDefinition>();
+            Assert.AreEqual(defaultSettings.EnablePartitioning, configuredTransport.EnablePartitioning);
+            Assert.AreEqual(defaultSettings.PrefetchCount, configuredTransport.PrefetchCount);
+            Assert.AreEqual(defaultSettings.PrefetchMultiplier, configuredTransport.PrefetchMultiplier);
+            Assert.AreEqual(defaultSettings.RetryPolicy, configuredTransport.RetryPolicy);
+            Assert.AreEqual(defaultSettings.TimeToWaitBeforeTriggeringCircuitBreaker, configuredTransport.TimeToWaitBeforeTriggeringCircuitBreaker);
+            Assert.AreEqual(defaultSettings.TokenProvider, configuredTransport.TokenProvider);
+            Assert.AreEqual(defaultSettings.UseWebSockets, configuredTransport.UseWebSockets);
+            Assert.AreEqual(defaultSettings.ConnectionString, configuredTransport.ConnectionString);
+            Assert.AreEqual(defaultSettings.EntityMaximumSize, configuredTransport.EntityMaximumSize);
+            Assert.AreEqual(defaultSettings.TopicName, configuredTransport.TopicName);
+            Assert.AreEqual(defaultSettings.TransportTransactionMode, configuredTransport.TransportTransactionMode);
+            Assert.AreEqual(
+                defaultSettings.SubscriptionNamingConvention("subscriptionName"),
+                configuredTransport.SubscriptionNamingConvention("subscriptionName"));
+            Assert.AreEqual(
+                defaultSettings.SubscriptionRuleNamingConvention(typeof(MigrationApiTests)),
+                defaultSettings.SubscriptionRuleNamingConvention(typeof(MigrationApiTests)));
+        }
+
+        [Test]
+        public void UseTransport_should_apply_settings()
+        {
+            var endpointConfiguration = new EndpointConfiguration(nameof(MigrationApiTests));
+
+            var settings = endpointConfiguration.UseTransport<AzureServiceBusTransport>("ConnectionString");
+
+            settings.EnablePartitioning();
+            RetryPolicy customRetryPolicy = RetryPolicy.NoRetry;
+            settings.CustomRetryPolicy(customRetryPolicy);
+            var customTokenProvider = new ManagedIdentityTokenProvider(null);
+            settings.CustomTokenProvider(customTokenProvider);
+            settings.EnablePartitioning();
+            settings.EntityMaximumSize(42);
+            settings.PrefetchCount(21);
+            settings.PrefetchMultiplier(1337);
+            settings.TimeToWaitBeforeTriggeringCircuitBreaker(TimeSpan.FromDays(365));
+            settings.TopicName("CustomTopicName");
+            settings.UseWebSockets();
+            settings.SubscriptionNamingConvention(_ => nameof(settings.SubscriptionNamingConvention));
+            settings.SubscriptionRuleNamingConvention(_ => nameof(settings.SubscriptionRuleNamingConvention));
+
+            var configuredTransport = (AzureServiceBusTransport)endpointConfiguration.GetSettings().Get<TransportDefinition>();
+
+            Assert.IsTrue(configuredTransport.EnablePartitioning);
+            Assert.AreEqual(customRetryPolicy, configuredTransport.RetryPolicy);
+            Assert.AreEqual(customTokenProvider, configuredTransport.TokenProvider);
+            Assert.IsTrue(configuredTransport.EnablePartitioning);
+            Assert.AreEqual(42, configuredTransport.EntityMaximumSize);
+            Assert.AreEqual(21, configuredTransport.PrefetchCount);
+            Assert.AreEqual(1337, configuredTransport.PrefetchMultiplier);
+            Assert.AreEqual(TimeSpan.FromDays(365), configuredTransport.TimeToWaitBeforeTriggeringCircuitBreaker);
+            Assert.AreEqual("CustomTopicName", configuredTransport.TopicName);
+            Assert.IsTrue(configuredTransport.UseWebSockets);
+            Assert.AreEqual(nameof(settings.SubscriptionNamingConvention), configuredTransport.SubscriptionNamingConvention(nameof(MigrationApiTests)));
+            Assert.AreEqual(nameof(settings.SubscriptionRuleNamingConvention), configuredTransport.SubscriptionRuleNamingConvention(typeof(MigrationApiTests)));
+        }
+    }
+}
+#pragma warning restore CS0618
+#pragma warning restore IDE0079 // Remove unnecessary suppression

--- a/src/Tests/MigrationApiTests.cs
+++ b/src/Tests/MigrationApiTests.cs
@@ -16,9 +16,10 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
         {
             var defaultSettings = new AzureServiceBusTransport("ConnectionString");
             var endpointConfiguration = new EndpointConfiguration(nameof(MigrationApiTests));
-            endpointConfiguration.UseTransport<AzureServiceBusTransport>("ConnectionString");
+            endpointConfiguration.UseTransport<AzureServiceBusTransport>();
 
             var configuredTransport = (AzureServiceBusTransport)endpointConfiguration.GetSettings().Get<TransportDefinition>();
+            Assert.IsNull(configuredTransport.ConnectionString);
             Assert.AreEqual(defaultSettings.EnablePartitioning, configuredTransport.EnablePartitioning);
             Assert.AreEqual(defaultSettings.PrefetchCount, configuredTransport.PrefetchCount);
             Assert.AreEqual(defaultSettings.PrefetchMultiplier, configuredTransport.PrefetchMultiplier);
@@ -26,7 +27,6 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             Assert.AreEqual(defaultSettings.TimeToWaitBeforeTriggeringCircuitBreaker, configuredTransport.TimeToWaitBeforeTriggeringCircuitBreaker);
             Assert.AreEqual(defaultSettings.TokenProvider, configuredTransport.TokenProvider);
             Assert.AreEqual(defaultSettings.UseWebSockets, configuredTransport.UseWebSockets);
-            Assert.AreEqual(defaultSettings.ConnectionString, configuredTransport.ConnectionString);
             Assert.AreEqual(defaultSettings.EntityMaximumSize, configuredTransport.EntityMaximumSize);
             Assert.AreEqual(defaultSettings.TopicName, configuredTransport.TopicName);
             Assert.AreEqual(defaultSettings.TransportTransactionMode, configuredTransport.TransportTransactionMode);
@@ -43,8 +43,9 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
         {
             var endpointConfiguration = new EndpointConfiguration(nameof(MigrationApiTests));
 
-            var settings = endpointConfiguration.UseTransport<AzureServiceBusTransport>("ConnectionString");
+            var settings = endpointConfiguration.UseTransport<AzureServiceBusTransport>();
 
+            settings.ConnectionString("ConnectionString");
             settings.EnablePartitioning();
             RetryPolicy customRetryPolicy = RetryPolicy.NoRetry;
             settings.CustomRetryPolicy(customRetryPolicy);

--- a/src/Tests/MigrationApiTests.cs
+++ b/src/Tests/MigrationApiTests.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus.Transport.AzureServiceBus.Tests
 {
     using System;
+    using System.Threading;
     using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.ServiceBus.Primitives;
     using NServiceBus.Configuration.AdvancedExtensibility;
@@ -75,6 +76,22 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             Assert.IsTrue(configuredTransport.UseWebSockets);
             Assert.AreEqual(nameof(settings.SubscriptionNamingConvention), configuredTransport.SubscriptionNamingConvention(nameof(MigrationApiTests)));
             Assert.AreEqual(nameof(settings.SubscriptionRuleNamingConvention), configuredTransport.SubscriptionRuleNamingConvention(typeof(MigrationApiTests)));
+        }
+
+        [Test]
+        public void Should_throw_when_no_connection_string_provided()
+        {
+            var endpointConfiguration = new EndpointConfiguration(nameof(MigrationApiTests));
+            endpointConfiguration.UseTransport<AzureServiceBusTransport>();
+
+            var configuredTransport = (AzureServiceBusTransport)endpointConfiguration.GetSettings().Get<TransportDefinition>();
+
+            var ex = Assert.ThrowsAsync<Exception>(() => configuredTransport.Initialize(
+                new HostSettings("test", "test", new StartupDiagnosticEntries(), (_, __, ___) => { }, false),
+                new ReceiveSettings[0],
+                new string[0],
+                CancellationToken.None));
+            StringAssert.Contains("No transport connection string has been configured via the 'ConnectionString' method. Provide a connection string using endpointConfig.UseTransport<AzureServiceBusTransport>().ConnectionString(connectionString)", ex.Message);
         }
     }
 }

--- a/src/Transport/AzureServiceBusSettings.cs
+++ b/src/Transport/AzureServiceBusSettings.cs
@@ -3,6 +3,7 @@
     using System;
     using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.ServiceBus.Primitives;
+    using Transport.AzureServiceBus;
 
     /// <summary>
     /// Provides a backwards-compatible configuration API for <see cref="AzureServiceBusTransport"/>.
@@ -12,6 +13,42 @@
         internal AzureServiceBusSettings(AzureServiceBusTransport transport, RoutingSettings<AzureServiceBusTransport> routing) : base(transport, routing)
         {
         }
+
+        /// <summary>
+        /// Configures the transport to use the connection string with the given name.
+        /// </summary>
+        [ObsoleteEx(
+            Message = "Provide the connection string to the AzureServiceBusTransport constructor",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings ConnectionString(string connectionString)
+        {
+            Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
+            Transport.ConnectionString = connectionString;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the transport to use the connection string with the given name.
+        /// </summary>
+        [ObsoleteEx(
+            Message =
+                "The ability to used named connection strings has been removed. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString)",
+            ReplacementTypeOrMember = "TransportExtensions.ConnectionString(connectionString)",
+            TreatAsErrorFromVersion = "2",
+            RemoveInVersion = "3")]
+        public AzureServiceBusSettings ConnectionStringName(string name) => throw new NotImplementedException();
+
+        /// <summary>
+        /// Configures the transport to use the given func as the connection string.
+        /// </summary>
+        [ObsoleteEx(
+            Message =
+                "Setting connection string at the endpoint level is no longer supported. Transport specific configuration options should be used instead",
+            TreatAsErrorFromVersion = "2",
+            RemoveInVersion = "3")]
+        public AzureServiceBusSettings ConnectionString(Func<string> connectionString) =>
+            throw new NotImplementedException();
 
         /// <summary>
         /// Specifies a callback to apply to the subscription name when the endpoint's name is longer than 50 characters.

--- a/src/Transport/AzureServiceBusSettings.cs
+++ b/src/Transport/AzureServiceBusSettings.cs
@@ -17,7 +17,7 @@
         /// Specifies a callback to apply to the subscription name when the endpoint's name is longer than 50 characters.
         /// </summary>
         [ObsoleteEx(
-            ReplacementTypeOrMember = "SubscriptionNamingConvention",
+            ReplacementTypeOrMember = "AzureServiceBusTransport.SubscriptionNamingConvention",
             TreatAsErrorFromVersion = "2",
             RemoveInVersion = "3")]
         public AzureServiceBusSettings SubscriptionNameShortener(Func<string, string> subscriptionNameShortener) =>
@@ -27,7 +27,7 @@
         /// Specifies a callback to apply to a subscription rule name when a subscribed event's name is longer than 50 characters.
         /// </summary>
         [ObsoleteEx(
-            ReplacementTypeOrMember = "SubscriptionNamingConvention",
+            ReplacementTypeOrMember = "AzureServiceBusTransport.SubscriptionRuleNamingConvention",
             TreatAsErrorFromVersion = "2",
             RemoveInVersion = "3")]
         public AzureServiceBusSettings RuleNameShortener(Func<string, string> ruleNameShortener) =>

--- a/src/Transport/AzureServiceBusSettings.cs
+++ b/src/Transport/AzureServiceBusSettings.cs
@@ -1,0 +1,179 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using Microsoft.Azure.ServiceBus;
+    using Microsoft.Azure.ServiceBus.Primitives;
+
+    /// <summary>
+    /// Provides a backwards-compatible configuration API for <see cref="AzureServiceBusTransport"/>.
+    /// </summary>
+    public class AzureServiceBusSettings : TransportSettings<AzureServiceBusTransport>
+    {
+        internal AzureServiceBusSettings(AzureServiceBusTransport transport, RoutingSettings<AzureServiceBusTransport> routing) : base(transport, routing)
+        {
+        }
+
+        /// <summary>
+        /// Specifies a callback to apply to the subscription name when the endpoint's name is longer than 50 characters.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "SubscriptionNamingConvention",
+            TreatAsErrorFromVersion = "2",
+            RemoveInVersion = "3")]
+        public AzureServiceBusSettings SubscriptionNameShortener(Func<string, string> subscriptionNameShortener) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Specifies a callback to apply to a subscription rule name when a subscribed event's name is longer than 50 characters.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "SubscriptionNamingConvention",
+            TreatAsErrorFromVersion = "2",
+            RemoveInVersion = "3")]
+        public AzureServiceBusSettings RuleNameShortener(Func<string, string> ruleNameShortener) =>
+            throw new NotImplementedException();
+
+        /// <summary>
+        /// Overrides the default topic name used to publish events between endpoints.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.TopicName",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings TopicName(string topicName)
+        {
+            Transport.TopicName = topicName;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default maximum size used when creating queues and topics.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.EntityMaximumSize",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings EntityMaximumSize(int maximumSizeInGB)
+        {
+            Transport.EntityMaximumSize = maximumSizeInGB;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables entity partitioning when creating queues and topics.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.EnablePartitioning",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings EnablePartitioning()
+        {
+            Transport.EnablePartitioning = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies the multiplier to apply to the maximum concurrency value to calculate the prefetch count.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.PrefetchMultiplier",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings PrefetchMultiplier(int prefetchMultiplier)
+        {
+            Transport.PrefetchMultiplier = prefetchMultiplier;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default prefetch count calculation with the specified value.
+        /// </summary>s
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.PrefetchCount",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings PrefetchCount(int prefetchCount)
+        {
+            Transport.PrefetchCount = prefetchCount;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default time to wait before triggering a circuit breaker that initiates the endpoint shutdown procedure when the message pump cannot successfully receive a message.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.TimeToWaitBeforeTriggeringCircuitBreaker",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings TimeToWaitBeforeTriggeringCircuitBreaker(TimeSpan timeToWait)
+        {
+            Transport.TimeToWaitBeforeTriggeringCircuitBreaker = timeToWait;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies a callback to customize subscription names.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.SubscriptionNamingConvention",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings SubscriptionNamingConvention(Func<string, string> subscriptionNamingConvention)
+        {
+            Transport.SubscriptionNamingConvention = subscriptionNamingConvention;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies a callback to customize subscription rule names.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.SubscriptionRuleNamingConvention",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings SubscriptionRuleNamingConvention(Func<Type, string> subscriptionRuleNamingConvention)
+        {
+            Transport.SubscriptionRuleNamingConvention = subscriptionRuleNamingConvention;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the transport to use AMQP over WebSockets.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.UseWebSockets",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings UseWebSockets()
+        {
+            Transport.UseWebSockets = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default token provider with a custom implementation.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.TokenProvider",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings CustomTokenProvider(ITokenProvider tokenProvider)
+        {
+            Transport.TokenProvider = tokenProvider;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default retry policy with a custom implementation.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "AzureServiceBusTransport.RetryPolicy",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public AzureServiceBusSettings CustomRetryPolicy(RetryPolicy retryPolicy)
+        {
+            Transport.RetryPolicy = retryPolicy;
+            return this;
+        }
+    }
+}

--- a/src/Transport/AzureServiceBusSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusSettingsExtensions.cs
@@ -12,10 +12,10 @@
             ReplacementTypeOrMember = "EndpointConfiguration.UseTransport(TransportDefinition)",
             TreatAsErrorFromVersion = "3",
             RemoveInVersion = "4")]
-        public static AzureServiceBusSettings UseTransport<TTransport>(this EndpointConfiguration endpointConfiguration, string connectionString)
+        public static AzureServiceBusSettings UseTransport<TTransport>(this EndpointConfiguration endpointConfiguration)
             where TTransport : AzureServiceBusTransport // scope this extension method to AzureServiceBusTransport
         {
-            var transportSettings = new AzureServiceBusTransport(connectionString);
+            var transportSettings = new AzureServiceBusTransport();
             var routing = endpointConfiguration.UseTransport(transportSettings);
             return new AzureServiceBusSettings(transportSettings, routing);
         }

--- a/src/Transport/AzureServiceBusSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusSettingsExtensions.cs
@@ -1,0 +1,23 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus
+{
+    /// <summary>
+    /// Provides configuration extension methods for API backwards compatibility.
+    /// </summary>
+    public static class AzureServiceBusSettingsExtensions
+    {
+        /// <summary>
+        /// Configures NServiceBus to use <see cref="AzureServiceBusTransport"/>.
+        /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "EndpointConfiguration.UseTransport(TransportDefinition)",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public static AzureServiceBusSettings UseTransport<TTransport>(this EndpointConfiguration endpointConfiguration, string connectionString)
+            where TTransport : AzureServiceBusTransport // scope this extension method to AzureServiceBusTransport
+        {
+            var transportSettings = new AzureServiceBusTransport(connectionString);
+            var routing = endpointConfiguration.UseTransport(transportSettings);
+            return new AzureServiceBusSettings(transportSettings, routing);
+        }
+    }
+}

--- a/src/Transport/AzureServiceBusSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusSettingsExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.AzureServiceBus
+﻿namespace NServiceBus
 {
     /// <summary>
     /// Provides configuration extension methods for API backwards compatibility.

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -29,12 +29,7 @@
         public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings,
             ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
         {
-            // Check if a connection string has been provided when using the shim configuration API.
-            if (string.IsNullOrWhiteSpace(ConnectionString))
-            {
-                throw new Exception(
-                    "No transport connection string has been configured via the 'ConnectionString' method. Provide a connection string using 'endpointConfig.UseTransport<AzureServiceBusTransport>().ConnectionString(connectionString)'.");
-            }
+            CheckConnectionStringHasBeenConfigured();
 
             var connectionStringBuilder = new ServiceBusConnectionStringBuilder(ConnectionString)
             {

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -36,7 +36,13 @@
         public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings,
             ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
         {
-            //TODO throw exception when connection string not set
+            // Check if a connection string has been provided when using the shim configuration API.
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                throw new Exception(
+                    "No transport connection string has been configured via the 'ConnectionString' method. Provide a connection string using 'endpointConfig.UseTransport<AzureServiceBusTransport>().ConnectionString(connectionString)'.");
+            }
+
             var connectionStringBuilder = new ServiceBusConnectionStringBuilder(ConnectionString)
             {
                 TransportType = UseWebSockets ? TransportType.AmqpWebSockets : TransportType.Amqp

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -11,8 +11,10 @@
     using Transport;
     using Transport.AzureServiceBus;
 
-    /// <summary>Transport definition for Azure Service Bus.</summary>
-    public class AzureServiceBusTransport : TransportDefinition
+    /// <summary>
+    /// Transport definition for Azure Service Bus.
+    /// </summary>
+    public partial class AzureServiceBusTransport : TransportDefinition
     {
         /// <summary>
         /// Creates a new instance of <see cref="AzureServiceBusTransport"/>.
@@ -21,15 +23,6 @@
         {
             Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
             ConnectionString = connectionString;
-        }
-
-        // Used by the shim API to enable easier migration from the existing API
-        internal AzureServiceBusTransport() : base(
-            defaultTransactionMode: TransportTransactionMode.SendsAtomicWithReceive,
-            supportsDelayedDelivery: true,
-            supportsPublishSubscribe: true,
-            supportsTTBR: true)
-        {
         }
 
         /// <inheritdoc />

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -17,20 +17,26 @@
         /// <summary>
         /// Creates a new instance of <see cref="AzureServiceBusTransport"/>.
         /// </summary>
-        public AzureServiceBusTransport(string connectionString) : base(
+        public AzureServiceBusTransport(string connectionString) : this()
+        {
+            Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
+            ConnectionString = connectionString;
+        }
+
+        // Used by the shim API to enable easier migration from the existing API
+        internal AzureServiceBusTransport() : base(
             defaultTransactionMode: TransportTransactionMode.SendsAtomicWithReceive,
             supportsDelayedDelivery: true,
             supportsPublishSubscribe: true,
             supportsTTBR: true)
         {
-            Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
-            ConnectionString = connectionString;
         }
 
         /// <inheritdoc />
         public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings,
             ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
         {
+            //TODO throw exception when connection string not set
             var connectionStringBuilder = new ServiceBusConnectionStringBuilder(ConnectionString)
             {
                 TransportType = UseWebSockets ? TransportType.AmqpWebSockets : TransportType.Amqp
@@ -239,6 +245,6 @@
         }
         RetryPolicy retryPolicy;
 
-        internal string ConnectionString { get; private set; }
+        internal string ConnectionString { get; set; }
     }
 }

--- a/src/Transport/obsoletes-v2.cs
+++ b/src/Transport/obsoletes-v2.cs
@@ -118,6 +118,8 @@ namespace NServiceBus
 
 namespace NServiceBus
 {
+    using System;
+
     public partial class AzureServiceBusTransport
     {
 
@@ -128,6 +130,16 @@ namespace NServiceBus
             supportsPublishSubscribe: true,
             supportsTTBR: true)
         {
+        }
+
+        void CheckConnectionStringHasBeenConfigured()
+        {
+            // Check if a connection string has been provided when using the shim configuration API.
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                throw new Exception(
+                    "No transport connection string has been configured via the 'ConnectionString' method. Provide a connection string using 'endpointConfig.UseTransport<AzureServiceBusTransport>().ConnectionString(connectionString)'.");
+            }
         }
     }
 }

--- a/src/Transport/obsoletes-v2.cs
+++ b/src/Transport/obsoletes-v2.cs
@@ -116,5 +116,21 @@ namespace NServiceBus
     }
 }
 
+namespace NServiceBus
+{
+    public partial class AzureServiceBusTransport
+    {
+
+        // Used by the shim API to enable easier migration from the existing API
+        internal AzureServiceBusTransport() : base(
+            defaultTransactionMode: TransportTransactionMode.SendsAtomicWithReceive,
+            supportsDelayedDelivery: true,
+            supportsPublishSubscribe: true,
+            supportsTTBR: true)
+        {
+        }
+    }
+}
+
 #pragma warning restore 1591
 #pragma warning restore 618

--- a/src/Transport/obsoletes-v2.cs
+++ b/src/Transport/obsoletes-v2.cs
@@ -28,7 +28,7 @@ namespace NServiceBus
         }
 
         [ObsoleteEx(
-            ReplacementTypeOrMember = "TransportDefinition.TopicName",
+            ReplacementTypeOrMember = "AzureServiceBusTransport.TopicName",
             TreatAsErrorFromVersion = "2",
             RemoveInVersion = "3")]
         public static TransportExtensions<AzureServiceBusTransport> TopicName(this TransportExtensions<AzureServiceBusTransport> transportExtensions, string topicName) => throw new NotImplementedException();

--- a/src/Transport/obsoletes-v2.cs
+++ b/src/Transport/obsoletes-v2.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
     public static class AzureServiceBusTransportSettingsExtensions
     {
         [ObsoleteEx(
-            ReplacementTypeOrMember = "SubscriptionNamingConvention",
+            ReplacementTypeOrMember = "AzureServiceBusTransport.SubscriptionNamingConvention",
             TreatAsErrorFromVersion = "2",
             RemoveInVersion = "3")]
         public static TransportExtensions<AzureServiceBusTransport> SubscriptionNameShortener(this TransportExtensions<AzureServiceBusTransport> transportExtensions, Func<string, string> subscriptionNameShortener)
@@ -19,7 +19,7 @@ namespace NServiceBus
         }
 
         [ObsoleteEx(
-            ReplacementTypeOrMember = "SubscriptionRuleNamingConvention",
+            ReplacementTypeOrMember = "AzureServiceBusTransport.SubscriptionRuleNamingConvention",
             TreatAsErrorFromVersion = "2",
             RemoveInVersion = "3")]
         public static TransportExtensions<AzureServiceBusTransport> RuleNameShortener(this TransportExtensions<AzureServiceBusTransport> transportExtensions, Func<string, string> ruleNameShortener)


### PR DESCRIPTION
Added the shim API to ease migration. This included special handling to also support the `ConnectionString` extension instead of having to provide it via the ctor.