### PR TITLE
Only discard messages with mismatching TestRunId

### DIFF
--- a/src/AcceptanceTests/TestIndependenceSkipBehavior.cs
+++ b/src/AcceptanceTests/TestIndependenceSkipBehavior.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using NUnit.Framework;
     using Pipeline;
 
     class TestIndependenceSkipBehavior : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
@@ -16,9 +17,9 @@
 
         public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
-            if (!context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) || runId != testRunId)
+            if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) && runId != testRunId)
             {
-                Console.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
+                TestContext.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
                 return Task.CompletedTask;
             }
 


### PR DESCRIPTION
Same change as made in the legacy ASB transport (https://github.com/Particular/NServiceBus.AzureServiceBus/pull/1011) in order to make the new acceptance tests introduced with #366 pass.