### PR TITLE
add missing comment

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -58,7 +58,7 @@
                     {
                         // Invoke sender and immediately return it back to the pool w/o awaiting for completion
                         tasks.Add(sender.SendAsync(message));
-
+                        //committable tx will not be committed because this scope is not the owner
                         scope.Complete();
                     }
                 }


### PR DESCRIPTION
Adds the same comment as on line 88 (https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/compare/master...tx-comment?quick_pull=1#diff-c6b0be4814ff55f20eda0f3d7d1cf54000b898f72b4c5fbefbe004793f3a39b8L88) to this line so that both calls to `scope.Complete` do have the same comment on