### PR TITLE
setup-azureservicebus-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,20 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
       (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    name: ${{ matrix.name }}
+    name: ${{ matrix.os-name }}-${{ matrix.framework }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ windows-2019, ubuntu-20.04 ]
+        framework: [ net6.0, netcoreapp3.1, net472 ]
         include:
           - os: windows-2019
-            name: Windows
+            os-name: Windows
           - os: ubuntu-20.04
-            name: Linux
+            os-name: Linux
+        exclude:
+          - os: ubuntu-20.04
+            framework: net472
       fail-fast: false
     steps:
       - name: Check for secrets
@@ -45,11 +50,9 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 6.0.x
-      - name: Setup .NET Core 3.1 runtime
-        uses: actions/setup-dotnet@v1.9.0
-        with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+            6.0.x
+            3.1.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages
@@ -69,4 +72,5 @@ jobs:
           connection-string-name: AzureServiceBus_ConnectionString
           tag: ASBTransport
       - name: Run tests
-        uses: Particular/run-tests-action@v1.0.0
+        run: dotnet test src --configuration Release --no-build --framework ${{ matrix.framework }} --logger "GitHubActions;report-warnings=false" -m:1
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,11 @@ on:
       - master
       - release-*
   pull_request:
-  pull_request_target:
   workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
 jobs:
   build:
-    if:
-      (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.os-name }}-${{ matrix.framework }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -37,15 +32,8 @@ jobs:
         shell: pwsh
         run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
       - name: Checkout
-        if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2.4.0
         with:
-          fetch-depth: 0
-      - name: Checkout for Dependabot
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2.4.0
-        with:
-          ref: 'refs/pull/${{ github.event.number }}/merge'
           fetch-depth: 0
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.9.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,6 @@ jobs:
         uses: Particular/setup-azureservicebus-action@v1.0.0
         with:
           connection-string-name: AzureServiceBus_ConnectionString
-          tag: setup-azureservicebus-action
+          tag: ASBTransport
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,27 +64,9 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
       - name: Setup Azure Service Bus
-        id: infra
-        shell: pwsh
-        run: |
-          $name = "psw-asb-$(Get-Random)"
-          echo "::set-output name=name::$name"
-          $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
-
-          echo "Creating Azure Service Bus namespace $name (This can take awhile.)"
-          $details = az servicebus namespace create --resource-group GitHubActions-RG --name $name --tags Package=ASBTransport RunnerOS=${{ runner.os }} $dateTag | ConvertFrom-Json
-
-          echo "Getting connection string"
-          $keys = az servicebus namespace authorization-rule keys list --resource-group GitHubActions-RG --namespace-name $name --name RootManageSharedAccessKey | ConvertFrom-Json
-          $connectString = $keys.primaryConnectionString
-          echo "::add-mask::$connectString"
-
-          echo "AzureServiceBus_ConnectionString=$connectString" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+        uses: Particular/setup-azureservicebus-action@v1.0.0
+        with:
+          connection-string-name: AzureServiceBus_ConnectionString
+          tag: setup-azureservicebus-action
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0
-      - name: Teardown infrastructure
-        if: ${{ always() }}
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          $ignore = az servicebus namespace delete --resource-group GitHubActions-RG --name ${{ steps.infra.outputs.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,6 @@ jobs:
           connection-string-name: AzureServiceBus_ConnectionString
           tag: ASBTransport
       - name: Run tests
-        uses: Particular/run-tests-action@framework-param
+        uses: Particular/run-tests-action@v1.1.0
         with:
           framework: ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,6 @@ jobs:
           connection-string-name: AzureServiceBus_ConnectionString
           tag: ASBTransport
       - name: Run tests
-        run: dotnet test src --configuration Release --no-build --framework ${{ matrix.framework }} --logger "GitHubActions;report-warnings=false" -m:1
-
+        uses: Particular/run-tests-action@framework-param
+        with:
+          framework: ${{ matrix.framework }}


### PR DESCRIPTION
There are several flaky tests when the suite is run among multiple frameworks, which is why none of the other PRs in this repo currently pass CI. Rather than fight it, just run each framework separately and benefit from 20m CI times instead of 45m.