### PR TITLE
Use TrySetResult instead of SetResult

### DIFF
--- a/src/TransportTests/When_MessageLockLostException_is_thrown_from_on_error.cs
+++ b/src/TransportTests/When_MessageLockLostException_is_thrown_from_on_error.cs
@@ -24,7 +24,7 @@
                 },
                 (_, __) =>
                 {
-                    onErrorCalled.SetResult(true);
+                    onErrorCalled.TrySetResult(true);
                     throw new ServiceBusException("from onError", ServiceBusFailureReason.MessageLockLost);
                 },
                 transactionMode,

--- a/src/TransportTests/When_MessageLockLostException_is_thrown_from_on_error.cs
+++ b/src/TransportTests/When_MessageLockLostException_is_thrown_from_on_error.cs
@@ -14,7 +14,7 @@
         [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
         public async Task Should_not_raise_critical_error(TransportTransactionMode transactionMode)
         {
-            var onErrorCalled = new TaskCompletionSource<bool>();
+            var onErrorCalled = CreateTaskCompletionSource<bool>();
             string criticalErrorDetails = null;
 
             await StartPump(

--- a/src/TransportTests/When_ServiceBusTimeoutException_is_thrown_from_on_error.cs
+++ b/src/TransportTests/When_ServiceBusTimeoutException_is_thrown_from_on_error.cs
@@ -14,7 +14,7 @@
         [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
         public async Task Should_not_raise_critical_error(TransportTransactionMode transactionMode)
         {
-            var onErrorCalled = new TaskCompletionSource<bool>();
+            var onErrorCalled = CreateTaskCompletionSource<bool>();
             string criticalErrorDetails = null;
 
             await StartPump(

--- a/src/TransportTests/When_ServiceBusTimeoutException_is_thrown_from_on_error.cs
+++ b/src/TransportTests/When_ServiceBusTimeoutException_is_thrown_from_on_error.cs
@@ -24,7 +24,7 @@
                 },
                 (_, __) =>
                 {
-                    onErrorCalled.SetResult(true);
+                    onErrorCalled.TrySetResult(true);
                     throw new ServiceBusException("from onError", ServiceBusFailureReason.ServiceTimeout);
                 },
                 transactionMode,


### PR DESCRIPTION
These tests occasionally fail (see https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/actions/runs/1934833391) because `SetResult` might be called multiple times, making the `onError` throwback behave differently:

1. message arrives and throws an exception in `onMessage`
2. invoke `onError`
3. `onError` calls `SetResult(true)`
4. `onError` throws `ServiceBusException`
5. internal exception handling calls `AbandonMessage`
6. Message is received again
7. exception thrown in `onMessage`
8. `onError is invoked again`
9. `onError` calls `SetResult(true)` and now throws an `InvalidOperationException` instead
10. The message pump exception handling invokes the critical error action since this in not an expected exception.