### PR TITLE
Fix invoking incorrect `ServiceBusAdministrationClient` constructor when using `TokenCredential` (release-2.0)

### DIFF
--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -51,8 +51,8 @@
 
             if (tokenCredential != null)
             {
-                var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
-                administrationClient = new ServiceBusAdministrationClient(connectionStringProperties.FullyQualifiedNamespace, tokenCredential);
+                var fullyQualifiedNamespace = ServiceBusConnectionStringProperties.Parse(connectionString).FullyQualifiedNamespace;
+                administrationClient = new ServiceBusAdministrationClient(fullyQualifiedNamespace, tokenCredential);
             }
             else
             {

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -49,9 +49,15 @@
             _ = settings.TryGet(SettingsKeys.CustomTokenCredential, out TokenCredential tc);
             tokenCredential = tc;
 
-            administrationClient = tokenCredential != null
-                ? new ServiceBusAdministrationClient(connectionString, tokenCredential)
-                : new ServiceBusAdministrationClient(connectionString);
+            if (tokenCredential != null)
+            {
+                var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
+                administrationClient = new ServiceBusAdministrationClient(connectionStringProperties.FullyQualifiedNamespace, tokenCredential);
+            }
+            else
+            {
+                administrationClient = new ServiceBusAdministrationClient(connectionString);
+            }
 
             namespacePermissions = new NamespacePermissions(administrationClient);
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -90,8 +90,10 @@
                 serviceBusClientOptions.RetryOptions = retryOptions;
             }
 
+            var fullyQualifiedNamespace = ServiceBusConnectionStringProperties.Parse(connectionString).FullyQualifiedNamespace;
+
             serviceBusClient = tokenCredential != null
-                    ? new ServiceBusClient(connectionString, tokenCredential, serviceBusClientOptions)
+                    ? new ServiceBusClient(fullyQualifiedNamespace, tokenCredential, serviceBusClientOptions)
                     : new ServiceBusClient(connectionString, serviceBusClientOptions);
 
             var receiveOptions = new ServiceBusReceiverOptions()

--- a/src/Transport/Sending/MessageSenderPool.cs
+++ b/src/Transport/Sending/MessageSenderPool.cs
@@ -21,8 +21,10 @@
                 serviceBusClientOptions.RetryOptions = retryOptions;
             }
 
+            var fullyQualifiedNamespace = ServiceBusConnectionStringProperties.Parse(connectionString).FullyQualifiedNamespace;
+
             defaultClient = tokenCredential != null
-                    ? new ServiceBusClient(connectionString, tokenCredential, serviceBusClientOptions)
+                    ? new ServiceBusClient(fullyQualifiedNamespace, tokenCredential, serviceBusClientOptions)
                     : new ServiceBusClient(connectionString, serviceBusClientOptions);
 
             senders = new ConcurrentDictionary<(string, ServiceBusClient), ConcurrentQueue<ServiceBusSender>>();


### PR DESCRIPTION
Resolves #588 , clone of #599 to get CI working.