### PR TITLE
Client management improvements

### DIFF
--- a/src/Tests/FakeSender.cs
+++ b/src/Tests/FakeSender.cs
@@ -40,8 +40,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             return Task.CompletedTask;
         }
 
-        public override Task SendMessagesAsync(ServiceBusMessageBatch messageBatch,
-            CancellationToken cancellationToken = new CancellationToken())
+        public override Task SendMessagesAsync(ServiceBusMessageBatch messageBatch, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             batchedMessages.Add(messageBatch);

--- a/src/Tests/FakeServiceBusClient.cs
+++ b/src/Tests/FakeServiceBusClient.cs
@@ -16,5 +16,15 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             }
             return Senders[queueOrTopicName];
         }
+
+        public override ServiceBusSender CreateSender(string queueOrTopicName, ServiceBusSenderOptions options)
+        {
+            if (!Senders.ContainsKey(queueOrTopicName))
+            {
+                var fakeSender = new FakeSender();
+                Senders[queueOrTopicName] = fakeSender;
+            }
+            return Senders[queueOrTopicName];
+        }
     }
 }

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -94,15 +94,13 @@
 #pragma warning restore CS0672 // Member overrides obsolete member
 
         /// <inheritdoc />
-        public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()
-        {
-            return new[]
+        public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes() =>
+            new[]
             {
                 TransportTransactionMode.None,
                 TransportTransactionMode.ReceiveOnly,
                 TransportTransactionMode.SendsAtomicWithReceive
             };
-        }
 
         /// <summary>
         /// The topic name used to publish events between endpoints.

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -50,7 +50,8 @@
                 var options = new ServiceBusClientOptions
                 {
                     TransportType = transportType,
-                    EnableCrossEntityTransactions = enableCrossEntityTransactions
+                    EnableCrossEntityTransactions = enableCrossEntityTransactions,
+                    Identifier = $"Client-{receiver.Id}-{receiver.ReceiveAddress}-{Guid.NewGuid()}"
                 };
                 ApplyRetryPolicyOptionsIfNeeded(options);
                 var client = TokenCredential != null
@@ -63,7 +64,8 @@
             {
                 TransportType = transportType,
                 // for the default client we never want things to automatically use cross entity transaction
-                EnableCrossEntityTransactions = false
+                EnableCrossEntityTransactions = false,
+                Identifier = $"Client-{hostSettings.Name}-{Guid.NewGuid()}"
             };
             ApplyRetryPolicyOptionsIfNeeded(defaultClientOptions);
             var defaultClient = TokenCredential != null

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -42,12 +42,15 @@
         public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings,
             ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
         {
+            var transportType = UseWebSockets ? ServiceBusTransportType.AmqpWebSockets : ServiceBusTransportType.AmqpTcp;
+            bool enableCrossEntityTransactions = TransportTransactionMode == TransportTransactionMode.SendsAtomicWithReceive;
+
             var receiveSettingsAndClientPairs = receivers.Select(receiver =>
             {
                 var options = new ServiceBusClientOptions
                 {
-                    TransportType = UseWebSockets ? ServiceBusTransportType.AmqpWebSockets : ServiceBusTransportType.AmqpTcp,
-                    EnableCrossEntityTransactions = TransportTransactionMode == TransportTransactionMode.SendsAtomicWithReceive
+                    TransportType = transportType,
+                    EnableCrossEntityTransactions = enableCrossEntityTransactions
                 };
                 ApplyRetryPolicyOptionsIfNeeded(options);
                 var client = TokenCredential != null
@@ -58,7 +61,7 @@
 
             var defaultClientOptions = new ServiceBusClientOptions
             {
-                TransportType = UseWebSockets ? ServiceBusTransportType.AmqpWebSockets : ServiceBusTransportType.AmqpTcp,
+                TransportType = transportType,
                 // for the default client we never want things to automatically use cross entity transaction
                 EnableCrossEntityTransactions = false
             };

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -32,7 +32,15 @@
             messageSenderRegistry = new MessageSenderRegistry(defaultClient);
 
             Dispatcher = new MessageDispatcher(messageSenderRegistry, transportSettings.TopicName);
-            Receivers = receiveSettingsAndClientPairs.ToDictionary(s => s.receiveSettings.Id, s => CreateMessagePump(s.receiveSettings, s.client));
+            Receivers = receiveSettingsAndClientPairs.ToDictionary(static settingsAndClient =>
+            {
+                var (receiveSettings, _) = settingsAndClient;
+                return receiveSettings.Id;
+            }, settingsAndClient =>
+            {
+                (ReceiveSettings receiveSettings, ServiceBusClient client) = settingsAndClient;
+                return CreateMessagePump(receiveSettings, client);
+            });
 
             WriteStartupDiagnostics(hostSettings.StartupDiagnostic);
         }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -91,7 +91,7 @@
                 ReceiveMode = transportSettings.TransportTransactionMode == TransportTransactionMode.None
                     ? ServiceBusReceiveMode.ReceiveAndDelete
                     : ServiceBusReceiveMode.PeekLock,
-                Identifier = Id,
+                Identifier = $"Processor-{Id}-{ReceiveAddress}-{Guid.NewGuid()}",
                 MaxConcurrentCalls = limitations.MaxConcurrency,
                 AutoCompleteMessages = false
             };

--- a/src/Transport/Sending/MessageSenderRegistry.cs
+++ b/src/Transport/Sending/MessageSenderRegistry.cs
@@ -34,15 +34,26 @@
 
         public Task Close(CancellationToken cancellationToken = default)
         {
+            static async Task CloseAndDispose(ServiceBusSender sender, CancellationToken cancellationToken)
+            {
+                await using (sender.ConfigureAwait(false))
+                {
+                    await sender.CloseAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+
             var tasks = new List<Task>(destinationToSenderMapping.Keys.Count);
             foreach (var key in destinationToSenderMapping.Keys)
             {
                 var queue = destinationToSenderMapping[key];
 
-                if (queue.IsValueCreated)
+                if (!queue.IsValueCreated)
                 {
-                    tasks.Add(queue.Value.CloseAsync(cancellationToken));
+                    continue;
                 }
+
+
+                tasks.Add(CloseAndDispose(queue.Value, cancellationToken));
             }
             return Task.WhenAll(tasks);
         }

--- a/src/Transport/Sending/MessageSenderRegistry.cs
+++ b/src/Transport/Sending/MessageSenderRegistry.cs
@@ -27,7 +27,7 @@
                     (string innerDestination, ServiceBusClient innerClient) = arg;
                     // Unfortunately Lazy closure allocates but this should be fine since the majority of the
                     // execution path will fall into the get and not the add.
-                    return new Lazy<ServiceBusSender>(() => innerClient.CreateSender(innerDestination), LazyThreadSafetyMode.ExecutionAndPublication);
+                    return new Lazy<ServiceBusSender>(() => innerClient.CreateSender(innerDestination, new ServiceBusSenderOptions { Identifier = $"Sender-{innerDestination}-{Guid.NewGuid()}" }), LazyThreadSafetyMode.ExecutionAndPublication);
                 });
             return lazySender.Value;
         }


### PR DESCRIPTION
Additional enhancements as a follow-up to #644 

- Makes sure all senders are properly disposed
- Makes sure all clients including the default client are disposed
- Makes sure the default client has never the cross entity transaction flag set to avoid accidentally using the feature where it makes no sense to use it
- Creates dedicated option types for the receivers and the default clients (for better clarity, even though the option type is internally cloned)
- Assigns more descriptive IDs to the various client types