### PR TITLE
Expose the MaxAutoLockRenewalDuration

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,6 +7,7 @@ namespace NServiceBus
         protected string ConnectionString { get; set; }
         public bool EnablePartitioning { get; set; }
         public int EntityMaximumSize { get; set; }
+        public System.TimeSpan? MaxAutoLockRenewalDuration { get; set; }
         public int? PrefetchCount { get; set; }
         public int PrefetchMultiplier { get; set; }
         public Azure.Messaging.ServiceBus.ServiceBusRetryOptions RetryPolicyOptions { get; set; }

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -185,6 +185,27 @@
         TimeSpan timeToWaitBeforeTriggeringCircuitBreaker = TimeSpan.FromMinutes(2);
 
         /// <summary>
+        /// Gets or sets the maximum duration within which the lock will be renewed automatically. This
+        /// value should be greater than the longest message lock duration.
+        /// </summary>
+        /// <value>The maximum duration during which message locks are automatically renewed. The default value is 5 minutes.</value>
+        /// <remarks>The message renew can continue for sometime in the background
+        /// after completion of message and result in a few false MessageLockLostExceptions temporarily.</remarks>
+        public TimeSpan? MaxAutoLockRenewalDuration
+        {
+            get => maxAutoLockRenewalDuration;
+            set
+            {
+                if (value.HasValue)
+                {
+                    Guard.AgainstNegative(nameof(MaxAutoLockRenewalDuration), value.Value);
+                    maxAutoLockRenewalDuration = value;
+                }
+            }
+        }
+        TimeSpan? maxAutoLockRenewalDuration;
+
+        /// <summary>
         /// Specifies a callback to customize subscription names.
         /// </summary>
         public Func<string, string> SubscriptionNamingConvention

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -96,6 +96,11 @@
                 AutoCompleteMessages = false
             };
 
+            if (transportSettings.MaxAutoLockRenewalDuration.HasValue)
+            {
+                receiveOptions.MaxAutoLockRenewalDuration = transportSettings.MaxAutoLockRenewalDuration.Value;
+            }
+
             processor = serviceBusClient.CreateProcessor(ReceiveAddress, receiveOptions);
             processor.ProcessErrorAsync += OnProcessorError;
             processor.ProcessMessageAsync += OnProcessMessage;


### PR DESCRIPTION
Builds on top of #639 

Exposes the `MaxAutoLockRenewalDuration` from the SDK and forwards that to the `ServiceBusProcessor` used in the message pump. The processor will continue to extend the message lock up to the specified time.

The SDK itself uses a default value of 5 minutes. I did only expose that fact over the documentation, but not hard-code the 5 minutes into the code. This makes sure we follow the same defaults as the underlying SDK. Another option would be to remove the remark entirely and just rely on the SDK defaults without mentioning on the documentation.

It is also possible to manually extend the lock in the message handling pipeline by getting access to the processor arguments available on the context (introduced in the referenced PR).