### PR TITLE
Enable the command line tool to use a namespace with DefaultAzureCredentials

### DIFF
--- a/src/CommandLine/CommandRunner.cs
+++ b/src/CommandLine/CommandRunner.cs
@@ -2,17 +2,24 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Azure.Identity;
     using Azure.Messaging.ServiceBus.Administration;
     using McMaster.Extensions.CommandLineUtils;
 
     static class CommandRunner
     {
-        public static async Task Run(CommandOption connectionString, Func<ServiceBusAdministrationClient, Task> func)
+        public static async Task Run(CommandOption connectionString, CommandOption fullyQualifiedNamespace, Func<ServiceBusAdministrationClient, Task> func)
         {
-            var connectionStringToUse = connectionString.HasValue() ? connectionString.Value() : Environment.GetEnvironmentVariable(EnvironmentVariableName);
-
-            var client = new ServiceBusAdministrationClient(connectionStringToUse);
-
+            ServiceBusAdministrationClient client;
+            if (fullyQualifiedNamespace.HasValue())
+            {
+                client = new ServiceBusAdministrationClient(fullyQualifiedNamespace.Value(), new DefaultAzureCredential());
+            }
+            else
+            {
+                var connectionStringToUse = connectionString.HasValue() ? connectionString.Value() : Environment.GetEnvironmentVariable(EnvironmentVariableName);
+                client = new ServiceBusAdministrationClient(connectionStringToUse);
+            }
             await func(client);
         }
 

--- a/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
+    <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -21,7 +21,7 @@
 
             var fullyQualifiedNamespace = new CommandOption("-n|--namespace", CommandOptionType.SingleValue)
             {
-                Description = "Sets the fully qualified namespace for connecting without the connection string"
+                Description = "Sets the fully qualified namespace for connecting with cached credentials, such as those from Azure PowerShell or CLI"
             };
             fullyQualifiedNamespace.OnValidate(v => ValidateConnectionAndNamespaceNotUsedTogether(connectionString, fullyQualifiedNamespace));
             connectionString.OnValidate(v => ValidateConnectionAndNamespaceNotUsedTogether(connectionString, fullyQualifiedNamespace));

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -34,6 +34,15 @@
         }
 
         [Test]
+        public async Task Create_endpoint_validates_namespace_and_connection_string_cannot_be_used_together()
+        {
+            var (_, error, exitCode) = await Execute($"endpoint create {EndpointName} --topic {TopicName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
+
+            Assert.AreEqual(1, exitCode);
+            StringAssert.Contains("The connection string and the namespace option cannot be used together.", error);
+        }
+
+        [Test]
         public async Task Subscribe_endpoint()
         {
             await DeleteQueue(QueueName);
@@ -48,6 +57,15 @@
             await VerifyQueue(QueueName);
             await VerifyTopic(TopicName);
             await VerifySubscription(TopicName, SubscriptionName, QueueName);
+        }
+
+        [Test]
+        public async Task Subscribe_endpoint_validates_namespace_and_connection_string_cannot_be_used_together()
+        {
+            var (_, error, exitCode) = await Execute($"endpoint subscribe {EndpointName} MyMessage1 --topic {TopicName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
+
+            Assert.AreEqual(1, exitCode);
+            StringAssert.Contains("The connection string and the namespace option cannot be used together.", error);
         }
 
         [Test]
@@ -69,6 +87,15 @@
         }
 
         [Test]
+        public async Task Unsubscribe_endpoint_validates_namespace_and_connection_string_cannot_be_used_together()
+        {
+            var (_, error, exitCode) = await Execute($"endpoint unsubscribe {EndpointName} MyMessage1 --topic {TopicName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
+
+            Assert.AreEqual(1, exitCode);
+            StringAssert.Contains("The connection string and the namespace option cannot be used together.", error);
+        }
+
+        [Test]
         public async Task Create_queue_when_it_does_not_exist()
         {
             await DeleteQueue(QueueName);
@@ -80,6 +107,15 @@
             Assert.IsFalse(output.Contains("skipping"));
 
             await VerifyQueue(QueueName);
+        }
+
+        [Test]
+        public async Task Create_queue_validates_namespace_and_connection_string_cannot_be_used_together()
+        {
+            var (_, error, exitCode) = await Execute($"queue create {QueueName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
+
+            Assert.AreEqual(1, exitCode);
+            StringAssert.Contains("The connection string and the namespace option cannot be used together.", error);
         }
 
         [Test]
@@ -111,11 +147,18 @@
             await VerifyQueueExists(false);
         }
 
+        [Test]
+        public async Task Delete_queue_validates_namespace_and_connection_string_cannot_be_used_together()
+        {
+            var (_, error, exitCode) = await Execute($"queue delete {QueueName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
+
+            Assert.AreEqual(1, exitCode);
+            StringAssert.Contains("The connection string and the namespace option cannot be used together.", error);
+        }
+
         [SetUp]
         public void Setup()
-        {
-            client = new ServiceBusAdministrationClient(Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString"));
-        }
+            => client = new ServiceBusAdministrationClient(Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString"));
 
         async Task VerifyQueue(string queueName, bool enablePartitioning = false, int size = 5 * 1024)
         {


### PR DESCRIPTION
Closes #562 

I have thought about adding tests to verify the credential chain works but ultimately figured it is too complex and not adding much value. Having tests that verify that part of the tool would require either every developer to have additional credentials on the machine or we could conditionally only execute the tests on the CI. For those, the azure/login action would establish the token and we could execute the tests but ultimately, we would only be testing the SDK so I figured it is not worth the complexity.