### PR TITLE
Some test coverage for the pump

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>5.0</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <LangVersion>10.0</LangVersion>
     <!-- To lock the version of Particular.Analyzers, for example, in a release branch, set this property in Custom.Build.props -->
     <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">1.8.0</ParticularAnalyzersVersion>
     <NServiceBusKey>0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92</NServiceBusKey>

--- a/src/Tests/FakeProcessor.cs
+++ b/src/Tests/FakeProcessor.cs
@@ -1,0 +1,27 @@
+namespace NServiceBus.Transport.AzureServiceBus.Tests
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus;
+
+    public class FakeProcessor : ServiceBusProcessor
+    {
+        public bool WasStarted { get; private set; }
+        public bool WasStopped { get; private set; }
+
+        public override Task StartProcessingAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            WasStarted = true;
+            return Task.CompletedTask;
+        }
+
+        public override Task StopProcessingAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            WasStopped = true;
+            return Task.CompletedTask;
+        }
+
+        public Task ProcessMessage(ServiceBusReceivedMessage message, ServiceBusReceiver receiver = null, CancellationToken cancellationToken = default)
+            => OnProcessMessageAsync(new ProcessMessageEventArgs(message, receiver ?? new FakeReceiver(), cancellationToken));
+    }
+}

--- a/src/Tests/FakeReceiver.cs
+++ b/src/Tests/FakeReceiver.cs
@@ -1,0 +1,33 @@
+namespace NServiceBus.Transport.AzureServiceBus.Tests
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus;
+
+    public class FakeReceiver : ServiceBusReceiver
+    {
+        readonly List<(ServiceBusReceivedMessage, IDictionary<string, object> propertiesToModify)> abandonedMessages = new();
+        readonly List<ServiceBusReceivedMessage> completedMessages = new();
+
+        public IReadOnlyCollection<(ServiceBusReceivedMessage, IDictionary<string, object> propertiesToModify)> AbandonedMessages
+            => abandonedMessages;
+
+        public IReadOnlyCollection<ServiceBusReceivedMessage> CompletedMessages
+            => completedMessages;
+
+        public override Task AbandonMessageAsync(ServiceBusReceivedMessage message, IDictionary<string, object> propertiesToModify = null,
+            CancellationToken cancellationToken = default)
+        {
+            abandonedMessages.Add((message, propertiesToModify ?? new Dictionary<string, object>(0)));
+            return Task.CompletedTask;
+        }
+
+        public override Task CompleteMessageAsync(ServiceBusReceivedMessage message,
+            CancellationToken cancellationToken = default)
+        {
+            completedMessages.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Tests/FakeServiceBusClient.cs
+++ b/src/Tests/FakeServiceBusClient.cs
@@ -6,24 +6,36 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
     public class FakeServiceBusClient : ServiceBusClient
     {
         public Dictionary<string, FakeSender> Senders { get; } = new Dictionary<string, FakeSender>();
+        public Dictionary<string, FakeProcessor> Processors { get; } = new Dictionary<string, FakeProcessor>();
 
         public override ServiceBusSender CreateSender(string queueOrTopicName)
         {
-            if (!Senders.ContainsKey(queueOrTopicName))
+            if (!Senders.TryGetValue(queueOrTopicName, out var fakeSender))
             {
-                Senders[queueOrTopicName] = new FakeSender();
+                fakeSender = new FakeSender();
+                Senders.Add(queueOrTopicName, fakeSender);
             }
-            return Senders[queueOrTopicName];
+            return fakeSender;
         }
 
         public override ServiceBusSender CreateSender(string queueOrTopicName, ServiceBusSenderOptions options)
         {
-            if (!Senders.ContainsKey(queueOrTopicName))
+            if (!Senders.TryGetValue(queueOrTopicName, out var fakeSender))
             {
-                var fakeSender = new FakeSender();
-                Senders[queueOrTopicName] = fakeSender;
+                fakeSender = new FakeSender();
+                Senders.Add(queueOrTopicName, fakeSender);
             }
-            return Senders[queueOrTopicName];
+            return fakeSender;
+        }
+
+        public override ServiceBusProcessor CreateProcessor(string queueName, ServiceBusProcessorOptions options)
+        {
+            if (!Processors.TryGetValue(queueName, out var fakeProcessor))
+            {
+                fakeProcessor = new FakeProcessor();
+                Processors.Add(queueName, fakeProcessor);
+            }
+            return fakeProcessor;
         }
     }
 }

--- a/src/Tests/Receiving/MessagePumpTests.cs
+++ b/src/Tests/Receiving/MessagePumpTests.cs
@@ -1,0 +1,79 @@
+namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MessagePumpTests
+    {
+        [Test]
+        public async Task Should_complete_message_upon_success()
+        {
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+
+            var pump = new MessagePump(fakeClient, null, new AzureServiceBusTransport(), "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            await pump.Initialize(new PushRuntimeSettings(1), (context, token) => Task.CompletedTask,
+                (context, token) => Task.FromResult(ErrorHandleResult.Handled), CancellationToken.None);
+            await pump.StartReceive();
+
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId");
+
+            await fakeClient.Processors["receiveAddress"].ProcessMessage(receivedMessage, fakeReceiver);
+
+            Assert.That(fakeReceiver.CompletedMessages, Has.Exactly(1)
+                .Matches<ServiceBusReceivedMessage>(message => message.MessageId == "SomeId"));
+            Assert.That(fakeReceiver.AbandonedMessages, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_abandon_message_upon_failure_with_retry_required()
+        {
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+
+            var pump = new MessagePump(fakeClient, null, new AzureServiceBusTransport(), "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            await pump.Initialize(new PushRuntimeSettings(1), (context, token) => Task.FromException<InvalidOperationException>(new InvalidOperationException()),
+                (context, token) => Task.FromResult(ErrorHandleResult.RetryRequired), CancellationToken.None);
+            await pump.StartReceive();
+
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId");
+
+            await fakeClient.Processors["receiveAddress"].ProcessMessage(receivedMessage, fakeReceiver);
+
+            Assert.That(fakeReceiver.AbandonedMessages, Has.Exactly(1)
+                .Matches<(ServiceBusReceivedMessage Message, IDictionary<string, object> Props)>(abandoned => abandoned.Message.MessageId == "SomeId"));
+            Assert.That(fakeReceiver.CompletedMessages, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_complete_message_upon_failure_with_handled()
+        {
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+
+            var pump = new MessagePump(fakeClient, null, new AzureServiceBusTransport(), "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            await pump.Initialize(new PushRuntimeSettings(1), (context, token) => Task.FromException<InvalidOperationException>(new InvalidOperationException()),
+                (context, token) => Task.FromResult(ErrorHandleResult.Handled), CancellationToken.None);
+            await pump.StartReceive();
+
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId");
+
+            await fakeClient.Processors["receiveAddress"].ProcessMessage(receivedMessage, fakeReceiver);
+
+            Assert.That(fakeReceiver.CompletedMessages, Has.Exactly(1)
+                .Matches<ServiceBusReceivedMessage>(message => message.MessageId == "SomeId"));
+            Assert.That(fakeReceiver.AbandonedMessages, Is.Empty);
+        }
+    }
+}

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -5,7 +5,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Description>Azure Service Bus transport for NServiceBus</Description>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Brings in some test coverage for some of the scenarios of the pump. Not everything is covered, and there is still some redundancy that I deliberately did not yet remove. With this in place, we hopefully are in a much better state to continue to evolve the pump and add more tests. For example, it is now possible to verify the processor event args are added to the context (which I will add as a subsequent PR).