### PR TITLE
Make the token credential and the fullyQualifiedNamespace a dedicated connection setting instead of misusing the connection string.

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -4,7 +4,7 @@ namespace NServiceBus
     public class AzureServiceBusTransport : NServiceBus.Transport.TransportDefinition
     {
         public AzureServiceBusTransport(string connectionString) { }
-        protected string ConnectionString { get; set; }
+        public AzureServiceBusTransport(string fullyQualifiedNamespace, Azure.Core.TokenCredential tokenCredential) { }
         public bool EnablePartitioning { get; set; }
         public int EntityMaximumSize { get; set; }
         public System.TimeSpan? MaxAutoLockRenewalDuration { get; set; }
@@ -14,7 +14,6 @@ namespace NServiceBus
         public System.Func<string, string> SubscriptionNamingConvention { get; set; }
         public System.Func<System.Type, string> SubscriptionRuleNamingConvention { get; set; }
         public System.TimeSpan TimeToWaitBeforeTriggeringCircuitBreaker { get; set; }
-        public Azure.Core.TokenCredential TokenCredential { get; set; }
         public string TopicName { get; set; }
         public bool UseWebSockets { get; set; }
         public System.Net.IWebProxy WebProxy { get; set; }
@@ -31,7 +30,11 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> ConnectionString(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.Func<string> connectionString) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> ConnectionString(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string connectionString) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> CustomRetryPolicy(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, Azure.Messaging.ServiceBus.ServiceBusRetryOptions retryPolicy) { }
+        [System.Obsolete("Use `CustomTokenCredential(string fullyQualifiedNamespace, TokenCredential tokenC" +
+            "redential)` instead. The member currently throws a NotImplementedException. Will" +
+            " be removed in version 4.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> CustomTokenCredential(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, Azure.Core.TokenCredential tokenCredential) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> CustomTokenCredential(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string fullyQualifiedNamespace, Azure.Core.TokenCredential tokenCredential) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> EnablePartitioning(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> EntityMaximumSize(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int maximumSizeInGB) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> PrefetchCount(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int prefetchCount) { }

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -27,7 +27,24 @@
             supportsTTBR: true)
         {
             Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
+
             ConnectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AzureServiceBusTransport"/>.
+        /// </summary>
+        public AzureServiceBusTransport(string fullyQualifiedNamespace, TokenCredential tokenCredential) : base(
+            defaultTransactionMode: TransportTransactionMode.SendsAtomicWithReceive,
+            supportsDelayedDelivery: true,
+            supportsPublishSubscribe: true,
+            supportsTTBR: true)
+        {
+            Guard.AgainstNullAndEmpty(nameof(fullyQualifiedNamespace), fullyQualifiedNamespace);
+            Guard.AgainstNull(nameof(tokenCredential), tokenCredential);
+
+            FullyQualifiedNamespace = fullyQualifiedNamespace;
+            TokenCredential = tokenCredential;
         }
 
         [PreObsolete(RemoveInVersion = "4", Note = "Will not be required by TransportExtensions methods anymore in 4.0")]
@@ -57,7 +74,7 @@
                 ApplyRetryPolicyOptionsIfNeeded(options);
                 ApplyWebProxyIfNeeded(options);
                 var client = TokenCredential != null
-                    ? new ServiceBusClient(ConnectionString, TokenCredential, options)
+                    ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, options)
                     : new ServiceBusClient(ConnectionString, options);
                 return (receiver, client);
             }).ToArray();
@@ -72,7 +89,7 @@
             ApplyRetryPolicyOptionsIfNeeded(defaultClientOptions);
             ApplyWebProxyIfNeeded(defaultClientOptions);
             var defaultClient = TokenCredential != null
-                ? new ServiceBusClient(ConnectionString, TokenCredential, defaultClientOptions)
+                ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, defaultClientOptions)
                 : new ServiceBusClient(ConnectionString, defaultClientOptions);
 
             var administrativeClient = TokenCredential != null ? new ServiceBusAdministrationClient(ConnectionString, TokenCredential) : new ServiceBusAdministrationClient(ConnectionString);
@@ -288,11 +305,6 @@
         public bool UseWebSockets { get; set; }
 
         /// <summary>
-        /// Overrides the default token provider.
-        /// </summary>
-        public TokenCredential TokenCredential { get; set; }
-
-        /// <summary>
         /// Overrides the default retry policy.
         /// </summary>
         public ServiceBusRetryOptions RetryPolicyOptions
@@ -320,9 +332,9 @@
         }
         IWebProxy webProxy;
 
-        /// <summary>
-        /// Configures the Service Bus connection string.
-        /// </summary>
-        protected internal string ConnectionString { get; set; }
+        internal string ConnectionString { get; set; }
+
+        internal string FullyQualifiedNamespace { get; set; }
+        internal TokenCredential TokenCredential { get; set; }
     }
 }

--- a/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
@@ -233,6 +233,7 @@
         public static TransportExtensions<AzureServiceBusTransport> CustomTokenCredential(this TransportExtensions<AzureServiceBusTransport> transportExtensions, string fullyQualifiedNamespace, TokenCredential tokenCredential)
         {
             Guard.AgainstNull(nameof(tokenCredential), tokenCredential);
+            Guard.AgainstNullAndEmpty(nameof(fullyQualifiedNamespace), fullyQualifiedNamespace);
             transportExtensions.Transport.FullyQualifiedNamespace = fullyQualifiedNamespace;
             transportExtensions.Transport.TokenCredential = tokenCredential;
             return transportExtensions;

--- a/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
@@ -224,14 +224,16 @@
         /// Overrides the default token credential with a custom one.
         /// </summary>
         /// <param name="transportExtensions"></param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified namespace.</param>
         /// <param name="tokenCredential">The token credential to be used.</param>
         [PreObsolete(
-            ReplacementTypeOrMember = "AzureServiceBusTransport.TokenCredential",
+            ReplacementTypeOrMember = "AzureServiceBusTransport(string fullyQualifiedNamespace, TokenCredential tokenCredential)",
             TreatAsErrorFromVersion = "4",
             RemoveInVersion = "5")]
-        public static TransportExtensions<AzureServiceBusTransport> CustomTokenCredential(this TransportExtensions<AzureServiceBusTransport> transportExtensions, TokenCredential tokenCredential)
+        public static TransportExtensions<AzureServiceBusTransport> CustomTokenCredential(this TransportExtensions<AzureServiceBusTransport> transportExtensions, string fullyQualifiedNamespace, TokenCredential tokenCredential)
         {
             Guard.AgainstNull(nameof(tokenCredential), tokenCredential);
+            transportExtensions.Transport.FullyQualifiedNamespace = fullyQualifiedNamespace;
             transportExtensions.Transport.TokenCredential = tokenCredential;
             return transportExtensions;
         }

--- a/src/Transport/obsoletes-v3.cs
+++ b/src/Transport/obsoletes-v3.cs
@@ -2,6 +2,7 @@
 namespace NServiceBus
 {
     using System;
+    using Azure.Core;
     using Azure.Messaging.ServiceBus;
     using Extensibility;
 
@@ -21,6 +22,12 @@ namespace NServiceBus
         public static TransportExtensions<AzureServiceBusTransport> SubscriptionNameShortener(
             this TransportExtensions<AzureServiceBusTransport> transportExtensions,
             Func<string, string> subscriptionNameShortener)
+            => throw new NotImplementedException();
+
+        [ObsoleteEx(ReplacementTypeOrMember = "CustomTokenCredential(string fullyQualifiedNamespace, TokenCredential tokenCredential)",
+            TreatAsErrorFromVersion = "3",
+            RemoveInVersion = "4")]
+        public static TransportExtensions<AzureServiceBusTransport> CustomTokenCredential(this TransportExtensions<AzureServiceBusTransport> transportExtensions, TokenCredential tokenCredential)
             => throw new NotImplementedException();
     }
 


### PR DESCRIPTION
- Fixes #604