### PR TITLE
Introduce ToTransactionScope as an extension on AzureServiceBusTransportTransaction

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -82,4 +82,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         public void Commit() { }
         public void Dispose() { }
     }
+    public static class AzureServiceBusTransportTransactionExtensions
+    {
+        public static System.Transactions.TransactionScope ToTransactionScope(this NServiceBus.Transport.AzureServiceBus.AzureServiceBusTransportTransaction azureServiceBusTransaction) { }
+    }
 }

--- a/src/Transport/AzureServiceBusTransportTransactionExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportTransactionExtensions.cs
@@ -1,0 +1,18 @@
+namespace NServiceBus.Transport.AzureServiceBus
+{
+    using System.Transactions;
+
+    /// <summary>
+    /// Provides extension methods for <see cref="AzureServiceBusTransportTransaction"/>
+    /// </summary>
+    public static class AzureServiceBusTransportTransactionExtensions
+    {
+        /// <summary>
+        /// Returns a new scope that takes into account the internally managed transaction by either
+        /// providing the transaction to the scope or creating a suppress scope.
+        /// </summary>
+        public static TransactionScope ToTransactionScope(
+            this AzureServiceBusTransportTransaction azureServiceBusTransaction) =>
+            azureServiceBusTransaction.Transaction.ToScope();
+    }
+}

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -274,7 +274,7 @@
 
                     await processMessageEventArgs.SafeCompleteMessageAsync(message,
                             transportSettings.TransportTransactionMode,
-                            azureServiceBusTransaction.Transaction,
+                            azureServiceBusTransaction,
                             cancellationToken: messageProcessingCancellationToken)
                         .ConfigureAwait(false);
 
@@ -298,7 +298,7 @@
                         {
                             await processMessageEventArgs.SafeCompleteMessageAsync(message,
                                     transportSettings.TransportTransactionMode,
-                                    azureServiceBusTransaction.Transaction,
+                                    azureServiceBusTransaction,
                                     cancellationToken: messageProcessingCancellationToken)
                                 .ConfigureAwait(false);
                         }


### PR DESCRIPTION
Brings the ability to turn the azure service bus transaction into a scope without having to expose the transaction property.

Successfully tested in https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/pull/553/files#diff-c3a09a3104709e83ceea80ee3b45cb50759a17e656370b36f86daada61f8bd1cR221