### PR TITLE
Move LangVersion into custom build props

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,6 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>5.0</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <LangVersion>10.0</LangVersion>
     <!-- To lock the version of Particular.Analyzers, for example, in a release branch, set this property in Custom.Build.props -->
     <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">1.8.0</ParticularAnalyzersVersion>
     <NServiceBusKey>0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92</NServiceBusKey>


### PR DESCRIPTION
[According to the sync](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/671) I should never had added into the `Directory.build.props`. So moving the LangVersion to the custom build props