### PR TITLE
Initialize SubscriptionManager outside MessagePump

### DIFF
--- a/src/Tests/Receiving/MessagePumpTests.cs
+++ b/src/Tests/Receiving/MessagePumpTests.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
             var fakeClient = new FakeServiceBusClient();
             var fakeReceiver = new FakeReceiver();
 
-            var pump = new MessagePump(fakeClient, null, new AzureServiceBusTransport(), "receiveAddress",
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport(), "receiveAddress",
                 new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
 
             await pump.Initialize(new PushRuntimeSettings(1), (context, token) => Task.CompletedTask,
@@ -38,7 +38,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
             var fakeClient = new FakeServiceBusClient();
             var fakeReceiver = new FakeReceiver();
 
-            var pump = new MessagePump(fakeClient, null, new AzureServiceBusTransport(), "receiveAddress",
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport(), "receiveAddress",
                 new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
 
             bool pumpWasCalled = false;
@@ -67,7 +67,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
             var fakeClient = new FakeServiceBusClient();
             var fakeReceiver = new FakeReceiver();
 
-            var pump = new MessagePump(fakeClient, null, new AzureServiceBusTransport(), "receiveAddress",
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport(), "receiveAddress",
                 new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
 
             await pump.Initialize(new PushRuntimeSettings(1), (context, token) => Task.FromException<InvalidOperationException>(new InvalidOperationException()),
@@ -89,7 +89,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
             var fakeClient = new FakeServiceBusClient();
             var fakeReceiver = new FakeReceiver();
 
-            var pump = new MessagePump(fakeClient, null, new AzureServiceBusTransport(), "receiveAddress",
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport(), "receiveAddress",
                 new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
 
             await pump.Initialize(new PushRuntimeSettings(1), (context, token) => Task.FromException<InvalidOperationException>(new InvalidOperationException()),

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using System.Transactions;
     using Azure.Messaging.ServiceBus;
-    using Azure.Messaging.ServiceBus.Administration;
     using Extensibility;
     using Logging;
 
@@ -31,12 +30,11 @@
 
         public MessagePump(
             ServiceBusClient serviceBusClient,
-            ServiceBusAdministrationClient administrativeClient,
             AzureServiceBusTransport transportSettings,
             string receiveAddress,
             ReceiveSettings receiveSettings,
             Action<string, Exception, CancellationToken> criticalErrorAction,
-            NamespacePermissions namespacePermissions)
+            SubscriptionManager subscriptionManager)
         {
             Id = receiveSettings.Id;
             ReceiveAddress = receiveAddress;
@@ -44,15 +42,7 @@
             this.transportSettings = transportSettings;
             this.receiveSettings = receiveSettings;
             this.criticalErrorAction = criticalErrorAction;
-
-            if (receiveSettings.UsePublishSubscribe)
-            {
-                Subscriptions = new SubscriptionManager(
-                    ReceiveAddress,
-                    transportSettings,
-                    administrativeClient,
-                    namespacePermissions);
-            }
+            Subscriptions = subscriptionManager;
         }
 
         public Task Initialize(


### PR DESCRIPTION
Small refactoring to remove some unnecessary dependencies from the `MessagePump` constructor