### PR TITLE
Use the FullyQualifiedNamespace instead of the connection string when the token credential is set

### DIFF
--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -89,7 +89,7 @@
                 ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, defaultClientOptions)
                 : new ServiceBusClient(ConnectionString, defaultClientOptions);
 
-            var administrativeClient = TokenCredential != null ? new ServiceBusAdministrationClient(ConnectionString, TokenCredential) : new ServiceBusAdministrationClient(ConnectionString);
+            var administrativeClient = TokenCredential != null ? new ServiceBusAdministrationClient(FullyQualifiedNamespace, TokenCredential) : new ServiceBusAdministrationClient(ConnectionString);
 
             var namespacePermissions = new NamespacePermissions(administrativeClient);
 


### PR DESCRIPTION
Backport of #701 to `release-3.0`