### PR TITLE
Fix minimum version in range wasn't updated for Azure.Messaging.ServiceBus in #677 - release-3.1

### DIFF
--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.11.0, 8.0.0)" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.11.1, 8.0.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Backport of:

- https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/720