### PR TITLE
Pause longer when circuit breaker has been triggered

### DIFF
--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -94,7 +94,20 @@
 
             messageProcessingCancellationTokenSource = new CancellationTokenSource();
 
-            circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker($"'{receiveSettings.ReceiveAddress}'", transportSettings.TimeToWaitBeforeTriggeringCircuitBreaker, ex => criticalErrorAction("Failed to receive message from Azure Service Bus.", ex, messageProcessingCancellationTokenSource.Token));
+            circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker($"'{receiveSettings.ReceiveAddress}'",
+                transportSettings.TimeToWaitBeforeTriggeringCircuitBreaker, ex =>
+                {
+                    criticalErrorAction("Failed to receive message from Azure Service Bus.", ex,
+                        messageProcessingCancellationTokenSource.Token);
+                }, () =>
+                {
+                    //We don't have to update the prefetch count since we are failing to receive anyway
+                    processor.UpdateConcurrency(1);
+                },
+                () =>
+                {
+                    processor.UpdateConcurrency(limitations.MaxConcurrency);
+                });
 
             await processor.StartProcessingAsync(cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
This is meant to address two issues
 - https://github.com/Particular/ServiceControl/issues/2907
 - https://github.com/Particular/ServiceControl/issues/3318
 
by checking the state of the circuit breaker when `Failure` is invoked. If the breaker has already been triggered, the method pauses for 10 seconds (instead of 1 second) to prevent flooding the logs. The issue affects both ServiceControl and regular endpoints.