### PR TITLE
Switch the transport to use UpdatePrefetchCount on the processor when rate limiting occurs

### DIFF
--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.11.1, 8.0.0)" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.12.0, 8.0.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -204,7 +204,6 @@
                 .ConfigureAwait(false);
         }
 
-
         public Task ChangeConcurrency(PushRuntimeSettings newLimitations, CancellationToken cancellationToken = default)
         {
             limitations = newLimitations;


### PR DESCRIPTION
This leverages the feature [I contributed to the Azure.Messaging.ServiceBus library](https://github.com/Azure/azure-sdk-for-net/pull/33162/) that was released as part of 7.12.0. With that approach, it is no longer necessary to stop and start the transport. We can now adjust the processor's concurrency and prefetch count. By setting the prefetch count the underlying AMQP link credit is updated automatically if it has changed. 