### PR TITLE
Load exception on debug log entry

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -182,7 +182,15 @@ To mitigate this problem reduce the message size by using the data bus or upgrad
                 batchCount++;
                 if (Log.IsDebugEnabled)
                 {
-                    Log.Debug($"Sending batch '{batchCount}' with '{messageBatch.Count}' message ids '{logBuilder!.ToString(0, logBuilder.Length - 1)}' to destination {destination}.");
+                    try
+                    {
+                        Log.Debug($"Sending batch '{batchCount}' with '{messageBatch.Count}' message ids '{logBuilder!.ToString(0, logBuilder.Length - 1)}' to destination {destination}.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error($"Exception occuered when logging debug info. BatchCount: '{batchCount}'. Is MessageBatch null? {messageBatch is null}. logBuilder is null? {logBuilder is null}. Destination = '{destination}'", ex);
+                        throw;
+                    }
                 }
 
                 using var scope = transaction.ToScope();

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -13,6 +13,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
     class MessageDispatcher : IMessageDispatcher
     {
+        static readonly DateTime start = DateTime.UtcNow;
         static readonly ILog Log = LogManager.GetLogger<MessageDispatcher>();
         static readonly Dictionary<string, List<IOutgoingTransportOperation>> emptyDestinationAndOperations = new();
 
@@ -188,7 +189,7 @@ To mitigate this problem reduce the message size by using the data bus or upgrad
                     }
                     catch (Exception ex)
                     {
-                        Log.Error($"Exception occuered when logging debug info. BatchCount: '{batchCount}'. Is MessageBatch null? {messageBatch is null}. logBuilder is null? {logBuilder is null}. Destination = '{destination}'", ex);
+                        Log.Error($"Exception occuered when logging debug info. BatchCount: '{batchCount}'. Is MessageBatch null? {messageBatch is null}. logBuilder is null? {logBuilder is null}. Destination = '{destination}'. Start time = {start}", ex);
                         throw;
                     }
                 }


### PR DESCRIPTION
Logs the values of all the relevant variables if a null-ref exception occurs on writing a debug statement.