### PR TITLE
Manage subscriptions without manage rights

### DIFF
--- a/src/AcceptanceTests/Receiving/When_publishing_from_different_topics.cs
+++ b/src/AcceptanceTests/Receiving/When_publishing_from_different_topics.cs
@@ -12,8 +12,6 @@ namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Receiving
         [Test]
         public async Task Should_be_delivered_to_all_subscribers_and_back_to_the_publisher()
         {
-            Requires.NativePubSubSupport();
-
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<PublisherOnTopicA>(b => b.When((session, c) => session.SendLocal(new MyCommand())))
                 .WithEndpoint<SubscriberOnTopicB>()

--- a/src/AcceptanceTests/Receiving/When_publishing_sendonly_and_subscribing_on_different_topics.cs
+++ b/src/AcceptanceTests/Receiving/When_publishing_sendonly_and_subscribing_on_different_topics.cs
@@ -11,8 +11,6 @@ namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Receiving
         [Test]
         public async Task Should_be_delivered_to_all_subscribers()
         {
-            Requires.NativePubSubSupport();
-
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<SendOnlyPublisherOnTopicA>(b => b.When((session, c) => session.Publish(new MyEvent())))
                 .WithEndpoint<SubscriberOnTopicB>()

--- a/src/AcceptanceTests/When_operating_with_least_privilege.cs
+++ b/src/AcceptanceTests/When_operating_with_least_privilege.cs
@@ -34,8 +34,6 @@ namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests
         [Test]
         public async Task Should_allow_message_operations_on_existing_resources()
         {
-            Requires.NativePubSubSupport();
-
             // Run the scenario first with manage rights to make sure the topic and the subscription is created
             await Scenario.Define<Context>()
                 .WithEndpoint<Publisher>(b =>

--- a/src/Transport/Administration/SubscriptionManager.cs
+++ b/src/Transport/Administration/SubscriptionManager.cs
@@ -66,17 +66,6 @@
             var sqlExpression = $"[{Headers.EnclosedMessageTypes}] LIKE '%{eventType.FullName}%'";
 
             // on an entity with forwarding enabled it is not possible to do GetRules so we first have to delete and then create
-            // to preserve the update or create behavior
-
-            try
-            {
-                await ruleManager.DeleteRuleAsync(ruleName, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (ServiceBusException createSbe) when (createSbe.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
-            {
-                // ignored due to race conditions
-            }
 
             try
             {

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -8,7 +8,6 @@
     using System.Threading.Tasks;
     using Azure.Core;
     using Azure.Messaging.ServiceBus;
-    using Azure.Messaging.ServiceBus.Administration;
     using Transport;
     using Transport.AzureServiceBus;
 
@@ -92,27 +91,27 @@
                 ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, defaultClientOptions)
                 : new ServiceBusClient(ConnectionString, defaultClientOptions);
 
-            var administrativeClient = TokenCredential != null ? new ServiceBusAdministrationClient(FullyQualifiedNamespace, TokenCredential) : new ServiceBusAdministrationClient(ConnectionString);
-
-            var namespacePermissions = new NamespacePermissions(administrativeClient);
-
-            var infrastructure = new AzureServiceBusTransportInfrastructure(this, hostSettings, receiveSettingsAndClientPairs, defaultClient, administrativeClient, namespacePermissions);
+            var infrastructure = new AzureServiceBusTransportInfrastructure(this, hostSettings, receiveSettingsAndClientPairs, defaultClient);
 
             if (hostSettings.SetupInfrastructure)
             {
-                var queueCreator = new QueueCreator(this, administrativeClient, namespacePermissions);
+                var namespacePermissions = new NamespacePermissions(TokenCredential, FullyQualifiedNamespace, ConnectionString);
+                var adminClient = await namespacePermissions.CanManage(cancellationToken)
+                    .ConfigureAwait(false);
+
+                var queueCreator = new QueueCreator(this);
                 var allQueues = infrastructure.Receivers
                     .Select(r => r.Value.ReceiveAddress)
                     .Concat(sendingAddresses)
                     .ToArray();
 
-                await queueCreator.CreateQueues(allQueues, cancellationToken).ConfigureAwait(false);
+                await queueCreator.CreateQueues(adminClient, allQueues, cancellationToken).ConfigureAwait(false);
 
                 foreach (IMessageReceiver messageReceiver in infrastructure.Receivers.Values)
                 {
                     if (messageReceiver.Subscriptions is SubscriptionManager subscriptionManager)
                     {
-                        await subscriptionManager.CreateSubscription(cancellationToken).ConfigureAwait(false);
+                        await subscriptionManager.CreateSubscription(adminClient, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -65,18 +65,18 @@
 
             var receiveSettingsAndClientPairs = receivers.Select(receiver =>
             {
-                var options = new ServiceBusClientOptions
+                var receiveClientOptions = new ServiceBusClientOptions
                 {
                     TransportType = transportType,
                     EnableCrossEntityTransactions = enableCrossEntityTransactions,
                     Identifier = $"Client-{receiver.Id}-{receiver.ReceiveAddress}-{Guid.NewGuid()}",
                 };
-                ApplyRetryPolicyOptionsIfNeeded(options);
-                ApplyWebProxyIfNeeded(options);
-                var client = TokenCredential != null
-                    ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, options)
-                    : new ServiceBusClient(ConnectionString, options);
-                return (receiver, client);
+                ApplyRetryPolicyOptionsIfNeeded(receiveClientOptions);
+                ApplyWebProxyIfNeeded(receiveClientOptions);
+                var receiveClient = TokenCredential != null
+                    ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, receiveClientOptions)
+                    : new ServiceBusClient(ConnectionString, receiveClientOptions);
+                return (receiver, receiveClient);
             }).ToArray();
 
             var defaultClientOptions = new ServiceBusClientOptions

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -5,29 +5,24 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
-    using Azure.Messaging.ServiceBus.Administration;
     using Transport;
 
     sealed class AzureServiceBusTransportInfrastructure : TransportInfrastructure
     {
         readonly AzureServiceBusTransport transportSettings;
 
-        readonly ServiceBusAdministrationClient administrationClient;
-        readonly NamespacePermissions namespacePermissions;
         readonly MessageSenderRegistry messageSenderRegistry;
         readonly HostSettings hostSettings;
         readonly ServiceBusClient defaultClient;
         readonly (ReceiveSettings receiveSettings, ServiceBusClient client)[] receiveSettingsAndClientPairs;
 
-        public AzureServiceBusTransportInfrastructure(AzureServiceBusTransport transportSettings, HostSettings hostSettings, (ReceiveSettings receiveSettings, ServiceBusClient client)[] receiveSettingsAndClientPairs, ServiceBusClient defaultClient, ServiceBusAdministrationClient administrationClient, NamespacePermissions namespacePermissions)
+        public AzureServiceBusTransportInfrastructure(AzureServiceBusTransport transportSettings, HostSettings hostSettings, (ReceiveSettings receiveSettings, ServiceBusClient client)[] receiveSettingsAndClientPairs, ServiceBusClient defaultClient)
         {
             this.transportSettings = transportSettings;
 
             this.hostSettings = hostSettings;
             this.defaultClient = defaultClient;
             this.receiveSettingsAndClientPairs = receiveSettingsAndClientPairs;
-            this.administrationClient = administrationClient;
-            this.namespacePermissions = namespacePermissions;
 
             messageSenderRegistry = new MessageSenderRegistry(defaultClient);
 
@@ -44,7 +39,6 @@
 
             WriteStartupDiagnostics(hostSettings.StartupDiagnostic);
         }
-
 
         void WriteStartupDiagnostics(StartupDiagnosticEntries startupDiagnostic) =>
             startupDiagnostic.Add("Azure Service Bus transport", new
@@ -70,8 +64,7 @@
                 receiveSettings,
                 hostSettings.CriticalErrorAction,
                 receiveSettings.UsePublishSubscribe
-                    ? new SubscriptionManager(receiveAddress, transportSettings, administrationClient,
-                        defaultClient, namespacePermissions)
+                    ? new SubscriptionManager(receiveAddress, transportSettings, defaultClient)
                     : null);
         }
 

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -38,8 +38,8 @@
                 return receiveSettings.Id;
             }, settingsAndClient =>
             {
-                (ReceiveSettings receiveSettings, ServiceBusClient client) = settingsAndClient;
-                return CreateMessagePump(receiveSettings, client);
+                (ReceiveSettings receiveSettings, ServiceBusClient receiveClient) = settingsAndClient;
+                return CreateMessagePump(receiveSettings, receiveClient);
             });
 
             WriteStartupDiagnostics(hostSettings.StartupDiagnostic);
@@ -60,18 +60,18 @@
                 CustomRetryPolicy = transportSettings.RetryPolicyOptions?.ToString() ?? "default"
             });
 
-        IMessageReceiver CreateMessagePump(ReceiveSettings receiveSettings, ServiceBusClient client)
+        IMessageReceiver CreateMessagePump(ReceiveSettings receiveSettings, ServiceBusClient receiveClient)
         {
             string receiveAddress = TranslateAddress(receiveSettings.ReceiveAddress);
             return new MessagePump(
-                client,
+                receiveClient,
                 transportSettings,
                 receiveAddress,
                 receiveSettings,
                 hostSettings.CriticalErrorAction,
                 receiveSettings.UsePublishSubscribe
                     ? new SubscriptionManager(receiveAddress, transportSettings, administrationClient,
-                        namespacePermissions)
+                        defaultClient, namespacePermissions)
                     : null);
         }
 


### PR DESCRIPTION
Closes #645 

This PR leverages the rule manager. The rule manager [doesn't support updating rules](https://github.com/Azure/azure-sdk-for-net/issues/31625), so we have to first delete the rules and then create them. It is also not possible to [enumerate rules on subscriptions with forwarding enabled](https://github.com/Azure/azure-sdk-for-net/pull/34816).