### PR TITLE
Detect oversized batch and throw

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -31,15 +31,7 @@
 
             foreach (var transportOperation in unicastTransportOperations)
             {
-                var destination = transportOperation.Destination;
-
-                // Workaround for reply-to address set by ASB transport
-                var index = transportOperation.Destination.IndexOf('@');
-
-                if (index > 0)
-                {
-                    destination = destination.Substring(0, index);
-                }
+                var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
 
                 var sender = messageSenderRegistry.GetMessageSender(destination, serviceBusClient);
 
@@ -53,7 +45,9 @@
 
             foreach (var transportOperation in multicastTransportOperations)
             {
-                var sender = messageSenderRegistry.GetMessageSender(topicName, serviceBusClient);
+                var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
+
+                var sender = messageSenderRegistry.GetMessageSender(destination, serviceBusClient);
 
                 var message = transportOperation.Message.ToAzureServiceBusMessage(transportOperation.DeliveryConstraints, partitionKey);
 

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -80,6 +80,13 @@
                 }
             }
 
+            if (transaction != null && numberOfDefaultOperations > 100)
+            {
+                // Azure Service Bus will throw an exception if we try to send too many messages in a single transaction https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas
+                // But the incoming message may not be handled properly after that https://github.com/Azure/azure-sdk-for-net/issues/37265
+                throw new Exception($"The number of outgoing messages ({numberOfDefaultOperations}) exceeds the limits permitted by Azure Service Bus (100) in a single transaction");
+            }
+
             var concurrentDispatchTasks = new List<Task>(numberOfIsolatedOperations + numberOfDefaultOperations);
             AddOperationsTo(concurrentDispatchTasks, isolatedOperationsPerDestination ?? EmptyDestinationAndOperations, context, serviceBusClient, partitionKey, null);
             AddOperationsTo(concurrentDispatchTasks, defaultOperationsPerDestination ?? EmptyDestinationAndOperations, context, serviceBusClient, partitionKey, committableTransaction);

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -27,23 +27,15 @@
             var unicastTransportOperations = outgoingMessages.UnicastTransportOperations;
             var multicastTransportOperations = outgoingMessages.MulticastTransportOperations;
 
+            var transportOperations =
+                new List<IOutgoingTransportOperation>(unicastTransportOperations.Count +
+                                                      multicastTransportOperations.Count);
+            transportOperations.AddRange(unicastTransportOperations);
+            transportOperations.AddRange(multicastTransportOperations);
+
             var tasks = new List<Task>(unicastTransportOperations.Count + multicastTransportOperations.Count);
 
-            foreach (var transportOperation in unicastTransportOperations)
-            {
-                var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
-
-                var sender = messageSenderRegistry.GetMessageSender(destination, serviceBusClient);
-
-                var message = transportOperation.Message.ToAzureServiceBusMessage(transportOperation.DeliveryConstraints, partitionKey);
-
-                ApplyCustomizationToOutgoingNativeMessage(context, transportOperation, message);
-
-                var transactionToUse = transportOperation.RequiredDispatchConsistency == DispatchConsistency.Isolated ? null : committableTransaction;
-                tasks.Add(DispatchOperation(sender, message, transactionToUse));
-            }
-
-            foreach (var transportOperation in multicastTransportOperations)
+            foreach (var transportOperation in transportOperations)
             {
                 var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
 

--- a/src/Transport/Sending/OutgoingTransportOperationExtensions.cs
+++ b/src/Transport/Sending/OutgoingTransportOperationExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus
+{
+    using System;
+
+    static class OutgoingTransportOperationExtensions
+    {
+        public static string ExtractDestination(this IOutgoingTransportOperation outgoingTransportOperation, string defaultMulticastRoute)
+        {
+            switch (outgoingTransportOperation)
+            {
+                case MulticastTransportOperation _:
+                    return defaultMulticastRoute;
+                case UnicastTransportOperation unicastTransportOperation:
+                    var destination = unicastTransportOperation.Destination;
+
+                    // Workaround for reply-to address set by ASB transport
+                    var index = unicastTransportOperation.Destination.IndexOf('@');
+
+                    if (index > 0)
+                    {
+                        destination = destination.Substring(0, index);
+                    }
+                    return destination;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outgoingTransportOperation));
+            }
+        }
+    }
+}


### PR DESCRIPTION
If you try to send more than 100 messages in a single transaction Azure Service Bus will throw an exception https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas

When that happens the incoming message is not handled properly https://github.com/Azure/azure-sdk-for-net/issues/37265

This change detects that you are trying to do this and does not attempt any dispatches.