### PR TITLE
Simpler detect oversized batch

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -71,10 +71,14 @@
             return tasks.Count == 1 ? tasks[0] : Task.WhenAll(tasks);
         }
 
-        static void AssertBelowMaxMessageThresholdForTransaction(List<UnicastTransportOperation> unicastTransportOperations, List<MulticastTransportOperation> multicastTransportOperations, CommittableTransaction committableTransaction)
+        /// <summary>
+        /// Throws an exception if attempting to send more than 100 messages in a transaction.
+        /// This prevents the transport from experiencing this issue https://github.com/Azure/azure-sdk-for-net/issues/37265
+        /// </summary>
+        static void AssertBelowMaxMessageThresholdForTransaction(List<UnicastTransportOperation> unicastTransportOperations, List<MulticastTransportOperation> multicastTransportOperations, Transaction transaction)
         {
             var totalNumberOfOperations = unicastTransportOperations.Count + multicastTransportOperations.Count;
-            if (committableTransaction == null || totalNumberOfOperations <= MaxMessageThresholdForTransaction)
+            if (transaction == null || totalNumberOfOperations <= MaxMessageThresholdForTransaction)
             {
                 return;
             }


### PR DESCRIPTION
- Alternative to #839 

Checks for attempts to send more than 100 messages in a single transaction, which is not allowed https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas and throws an exception.

Compared to #839 this PR makes minimal changes to the dispatcher. It iterates through the outgoing transactions only if the total count is high enough to potentially go over th limit, and if we are participating in a transaction.