### PR TITLE
Detect oversized batch 3

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -31,15 +31,7 @@
 
             foreach (var transportOperation in unicastTransportOperations)
             {
-                var destination = transportOperation.Destination;
-
-                // Workaround for reply-to address set by ASB transport
-                var index = transportOperation.Destination.IndexOf('@');
-
-                if (index > 0)
-                {
-                    destination = destination.Substring(0, index);
-                }
+                var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
 
                 var sender = messageSenderRegistry.GetMessageSender(destination, serviceBusClient);
 
@@ -53,7 +45,9 @@
 
             foreach (var transportOperation in multicastTransportOperations)
             {
-                var sender = messageSenderRegistry.GetMessageSender(topicName, serviceBusClient);
+                var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
+
+                var sender = messageSenderRegistry.GetMessageSender(destination, serviceBusClient);
 
                 var message = transportOperation.Message.ToAzureServiceBusMessage(transportOperation.DeliveryConstraints, partitionKey);
 

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -10,7 +10,7 @@
     class MessageDispatcher : IDispatchMessages
     {
         const int MaxMessageThresholdForTransaction = 100;
-        
+
         readonly MessageSenderRegistry messageSenderRegistry;
         readonly string topicName;
 

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -27,23 +27,13 @@
             var unicastTransportOperations = outgoingMessages.UnicastTransportOperations;
             var multicastTransportOperations = outgoingMessages.MulticastTransportOperations;
 
+            var transportOperations = new List<IOutgoingTransportOperation>(unicastTransportOperations.Count + multicastTransportOperations.Count);
+            transportOperations.AddRange(unicastTransportOperations);
+            transportOperations.AddRange(multicastTransportOperations);
+
             var tasks = new List<Task>(unicastTransportOperations.Count + multicastTransportOperations.Count);
 
-            foreach (var transportOperation in unicastTransportOperations)
-            {
-                var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
-
-                var sender = messageSenderRegistry.GetMessageSender(destination, serviceBusClient);
-
-                var message = transportOperation.Message.ToAzureServiceBusMessage(transportOperation.DeliveryConstraints, partitionKey);
-
-                ApplyCustomizationToOutgoingNativeMessage(context, transportOperation, message);
-
-                var transactionToUse = transportOperation.RequiredDispatchConsistency == DispatchConsistency.Isolated ? null : committableTransaction;
-                tasks.Add(DispatchOperation(sender, message, transactionToUse));
-            }
-
-            foreach (var transportOperation in multicastTransportOperations)
+            foreach (var transportOperation in transportOperations)
             {
                 var destination = transportOperation.ExtractDestination(defaultMulticastRoute: topicName);
 

--- a/src/Transport/Sending/OutgoingTransportOperationExtensions.cs
+++ b/src/Transport/Sending/OutgoingTransportOperationExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus
+{
+    using System;
+
+    static class OutgoingTransportOperationExtensions
+    {
+        public static string ExtractDestination(this IOutgoingTransportOperation outgoingTransportOperation, string defaultMulticastRoute)
+        {
+            switch (outgoingTransportOperation)
+            {
+                case MulticastTransportOperation _:
+                    return defaultMulticastRoute;
+                case UnicastTransportOperation unicastTransportOperation:
+                    var destination = unicastTransportOperation.Destination;
+
+                    // Workaround for reply-to address set by ASB transport
+                    var index = unicastTransportOperation.Destination.IndexOf('@');
+
+                    if (index > 0)
+                    {
+                        destination = destination.Substring(0, index);
+                    }
+                    return destination;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outgoingTransportOperation));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Alternative to #840
- Alternative to #839

This version counts transactional operations as we go and throws once we exceed the limit. This means that we will try and dispatch the first 100 messages and throw when we try to dispatch the 101st