### PR TITLE
Detect and throw when attempting to send more than 100 messages inside a transaction

### DIFF
--- a/src/Transport/AzureServiceBusTransportTransaction.cs
+++ b/src/Transport/AzureServiceBusTransportTransaction.cs
@@ -71,7 +71,7 @@ namespace NServiceBus.Transport.AzureServiceBus
             }
         }
 
-        internal bool HasTransaction => transactionIsInitialized || transactionOptions.HasValue;
+        internal bool HasTransaction => transaction != null || transactionOptions.HasValue;
 
         internal ServiceBusClient? ServiceBusClient
         {

--- a/src/Transport/AzureServiceBusTransportTransaction.cs
+++ b/src/Transport/AzureServiceBusTransportTransaction.cs
@@ -71,6 +71,8 @@ namespace NServiceBus.Transport.AzureServiceBus
             }
         }
 
+        internal bool HasTransaction => transactionIsInitialized || transactionOptions.HasValue;
+
         internal ServiceBusClient? ServiceBusClient
         {
             get;


### PR DESCRIPTION
_Addresses #817_
_Forward ports https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/840 to v3 of the transport_

When sending messages inside a receive transaction, it is possible for some messages to be sent by the dispatcher outside of the transaction, even without using isolated dispatch consistency.

## Symptoms

When an endpoint is configured to use SendsAtomicWithReceive transaction mode, and a handler attempts to dispatch more than 100 messages (which is [not supported by the Azure Service bus service](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas)), message processing fails, causing the message to be moved to the error queue. Depending on the number of messages dispatched (the higher, the more risk), the message to the error queue becomes stuck in transfer for an unknown amount of time and is sometimes completely lost.

## Who's affected?

You are affected if you have any endpoints that fulfill all of the following:

- The endpoint is using NServiceBus.Transport.AzureServiceBus 3.x.
- The endpoint is using [the SendsAtomicWithReceive transaction mode option](https://docs.particular.net/transports/transactions#transactions-transport-transaction-sends-atomic-with-receive), which is the default behavior. 
- The endpoint contains a message handler that can attempt to send more than 100 messages.

## Root cause 

The issue originates in the Azure SDK and has been [captured in the Azure SDK repo](https://github.com/Azure/azure-sdk-for-net/issues/37265).

## Fix

If you try to send more than 100 messages in a single transaction Azure Service Bus will throw an exception.
This change detects any handler attempting to do so and throws before dispatching any messages.