### PR TITLE
[DO NOT MERGE] Spike correlation filter support

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -13,6 +13,7 @@ namespace NServiceBus
         public int PrefetchMultiplier { get; set; }
         public Azure.Messaging.ServiceBus.ServiceBusRetryOptions RetryPolicyOptions { get; set; }
         public System.Func<string, string> SubscriptionNamingConvention { get; set; }
+        public System.Func<System.Type, Azure.Messaging.ServiceBus.Administration.RuleFilter> SubscriptionRuleFilterConvention { get; set; }
         public System.Func<System.Type, string> SubscriptionRuleNamingConvention { get; set; }
         public System.TimeSpan TimeToWaitBeforeTriggeringCircuitBreaker { get; set; }
         [System.Obsolete("It is possible to represent the publish and subscribe topic separately by specify" +

--- a/src/Transport/Administration/SubscriptionManager.cs
+++ b/src/Transport/Administration/SubscriptionManager.cs
@@ -63,13 +63,13 @@
             CancellationToken cancellationToken)
         {
             var ruleName = transportSettings.SubscriptionRuleNamingConvention(eventType);
-            var sqlExpression = $"[{Headers.EnclosedMessageTypes}] LIKE '%{eventType.FullName}%'";
 
             // on an entity with forwarding enabled it is not possible to do GetRules so we first have to delete and then create
 
             try
             {
-                await ruleManager.CreateRuleAsync(new CreateRuleOptions(ruleName, new SqlRuleFilter(sqlExpression)), cancellationToken)
+                var rule = transportSettings.SubscriptionRuleFilterConvention(eventType);
+                await ruleManager.CreateRuleAsync(new CreateRuleOptions(ruleName, rule), cancellationToken)
                     .ConfigureAwait(false);
             }
             catch (ServiceBusException createSbe) when (createSbe.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -8,6 +8,7 @@
     using System.Threading.Tasks;
     using Azure.Core;
     using Azure.Messaging.ServiceBus;
+    using Azure.Messaging.ServiceBus.Administration;
     using Transport;
     using Transport.AzureServiceBus;
 
@@ -343,6 +344,21 @@
             }
         }
         IWebProxy webProxy;
+
+        /// <summary>
+        /// Overrides the default subscription rule filter convention.
+        /// </summary>
+        public Func<Type, RuleFilter> SubscriptionRuleFilterConvention
+        {
+            get => subscriptionRuleFilterConventions;
+            set
+            {
+                Guard.AgainstNull(nameof(SubscriptionRuleFilterConvention), value);
+                subscriptionRuleFilterConventions = value;
+            }
+        }
+
+        Func<Type, RuleFilter> subscriptionRuleFilterConventions = eventType => new SqlRuleFilter($"[{Headers.EnclosedMessageTypes}] LIKE '%{eventType.FullName}%'");
 
         internal string ConnectionString { get; set; }
 

--- a/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
+++ b/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus.Administration;
 using NServiceBus;
 using NServiceBus.Transport;
 using NServiceBus.TransportTests;
@@ -39,7 +40,8 @@ public class ConfigureAzureServiceBusTransportInfrastructure : IConfigureTranspo
                         return sb.ToString();
                     }
                 }
-            }
+            },
+            SubscriptionRuleFilterConvention = eventType => new CorrelationRuleFilter(eventType.FullName)
         };
         return transport;
     }


### PR DESCRIPTION
Enables overriding the default subscription rule filter and runs the tests against correlation filters.

This is probably not how we would do this, but it should hopefully demonstrate that everything still works.