### PR TITLE
Update Azure.Identity to non-vulnerable version

### DIFF
--- a/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.13.1" />
-    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NServiceBus" Version="8.0.3" />
+    <PackageReference Include="NServiceBus" Version="8.0.8" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.13.1, 8.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.8, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Azure.Identity < 1.10.2 is affected by [CVE-2023-36414](https://github.com/advisories/GHSA-5mfx-4wcx-rv27).

This PR updates the version of Azure.Identity used by the `asb-transport` command line (CLI) tool to 1.10.4.
