### PR TITLE
Provide an additional point for users to troubleshoot max message size exception

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -173,8 +173,8 @@ namespace NServiceBus.Transport.AzureServiceBus
                     peekedMessage.ApplicationProperties.TryGetValue(Headers.MessageId, out var messageId);
                     var message =
                         @$"Unable to add the message '#{messageCount - messagesToSend.Count}' with message id '{messageId ?? peekedMessage.MessageId}' to the the batch '#{batchCount}'.
-The message may be too large or the batch size has reached the maximum allowed messages per batch for the current tier selected for the namespace '{sender.FullyQualifiedNamespace}'.
-To mitigate this problem reduce the message size by using the data bus or upgrade to a higher Service Bus tier.";
+The message may be too large, or the batch size has reached the maximum allowed messages per batch for the current tier selected for the namespace '{sender.FullyQualifiedNamespace}'.
+To mitigate this problem reduce the message size by using the data bus or upgrade to a higher Service Bus tier. If maximum message size has been changed, ensure to restart your endpoints.";
                     throw new ServiceBusException(message, ServiceBusFailureReason.MessageSizeExceeded);
                 }
 


### PR DESCRIPTION
When the maximum message size is changed but endpoints are not restarted, ASB client holds on to the old maximum message size, causing the transport to fail on the messages that otherwise would be OK to send using safe batching API.

SDK issue: https://github.com/Azure/azure-sdk-for-net/issues/43983