### PR TITLE
Cancel the pipeline execution when the lock is lost

### DIFF
--- a/src/Tests/FakeProcessor.cs
+++ b/src/Tests/FakeProcessor.cs
@@ -1,11 +1,15 @@
+#nullable enable
 namespace NServiceBus.Transport.AzureServiceBus.Tests
 {
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
 
     public class FakeProcessor : ServiceBusProcessor
     {
+        readonly ConditionalWeakTable<ServiceBusReceivedMessage, CustomProcessMessageEventArgs>
+            receivedMessageToEventArgs = [];
         public bool WasStarted { get; private set; }
         public bool WasStopped { get; private set; }
 
@@ -21,7 +25,27 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             return Task.CompletedTask;
         }
 
-        public Task ProcessMessage(ServiceBusReceivedMessage message, ServiceBusReceiver receiver = null, CancellationToken cancellationToken = default)
-            => OnProcessMessageAsync(new ProcessMessageEventArgs(message, receiver ?? new FakeReceiver(), cancellationToken));
+        public Task ProcessMessage(ServiceBusReceivedMessage message, ServiceBusReceiver? receiver = null, CancellationToken cancellationToken = default)
+        {
+            var eventArgs = new CustomProcessMessageEventArgs(message, receiver ?? new FakeReceiver(), cancellationToken);
+            receivedMessageToEventArgs.Add(message, eventArgs);
+            return OnProcessMessageAsync(eventArgs);
+        }
+
+        public Task RaiseMessageLockLost(ServiceBusReceivedMessage message, MessageLockLostEventArgs args, CancellationToken cancellationToken = default)
+            => receivedMessageToEventArgs.TryGetValue(message, out var eventArgs) ? eventArgs.RaiseMessageLockLost(args, cancellationToken) : Task.FromCanceled(cancellationToken);
+
+        sealed class CustomProcessMessageEventArgs : ProcessMessageEventArgs
+        {
+            public CustomProcessMessageEventArgs(ServiceBusReceivedMessage message, ServiceBusReceiver receiver, CancellationToken cancellationToken) : base(message, receiver, cancellationToken)
+            {
+            }
+
+            public CustomProcessMessageEventArgs(ServiceBusReceivedMessage message, ServiceBusReceiver receiver, string identifier, CancellationToken cancellationToken) : base(message, receiver, identifier, cancellationToken)
+            {
+            }
+
+            public Task RaiseMessageLockLost(MessageLockLostEventArgs args, CancellationToken cancellationToken = default) => OnMessageLockLostAsync(args);
+        }
     }
 }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -347,9 +347,11 @@
                 }
                 catch (Exception onErrorEx)
                 {
+                    // Using messageProcessingCancellationToken to make sure the critical error action can continue
+                    // to execute until the message processing is stopped.
                     criticalErrorAction(
                         $"Failed to execute recoverability policy for message with native ID: `{message.MessageId}`",
-                        onErrorEx, processingTokenSource.Token);
+                        onErrorEx, messageProcessingCancellationToken);
 
                     await processMessageEventArgs.SafeAbandonMessageAsync(message,
                             transportSettings.TransportTransactionMode,

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -366,7 +366,7 @@
 
             async Task MessageLockLostHandler(MessageLockLostEventArgs lockLostArgs)
             {
-                //logger.LogInformation(lockLostArgs.Exception, "Lost the lock while processing message. Cancelling the handler");
+                Logger.Info("Lost the lock while processing message. Cancelling the pipeline execution.", lockLostArgs.Exception);
                 try
                 {
                     await processingTokenSource.CancelAsync().ConfigureAwait(false);
@@ -374,7 +374,7 @@
                 catch (ObjectDisposedException)
                 {
                     // ignored
-                    //logger.LogCritical(lockLostArgs.Exception, "Lock lost handler executed but cancellation token source was already disposed.");
+                    Logger.Info("Lock lost handler executed but cancellation token source was already disposed.", lockLostArgs.Exception);
                 }
             }
         }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -196,7 +196,7 @@
             }
             catch (Exception ex) when (ex.IsCausedBy(messageProcessingCancellationTokenSource.Token))
             {
-                Logger.Debug("Message processing canceled.", ex);
+                Logger.Debug($"Processing of the message with id '{messageId}' canceled.", ex);
             }
         }
 
@@ -333,7 +333,7 @@
                 catch (ServiceBusException onErrorEx) when (onErrorEx.IsTransient ||
                                                             onErrorEx.Reason is ServiceBusFailureReason.MessageLockLost)
                 {
-                    Logger.Debug("Failed to execute recoverability.", onErrorEx);
+                    Logger.Debug($"Failed to execute recoverability for the message with id '{messageId}'.", onErrorEx);
 
                     await processMessageEventArgs.SafeAbandonMessageAsync(message,
                             transportSettings.TransportTransactionMode,
@@ -365,7 +365,7 @@
 
             async Task MessageLockLostHandler(MessageLockLostEventArgs lockLostArgs)
             {
-                Logger.Info("Lost the lock while processing message. Cancelling the pipeline execution.", lockLostArgs.Exception);
+                Logger.Info($"Lost the lock while processing the message with id '{messageId}'. Cancelling the pipeline execution.", lockLostArgs.Exception);
                 try
                 {
                     await lockLostCancellationTokenSource.CancelAsync().ConfigureAwait(false);
@@ -373,7 +373,7 @@
                 catch (ObjectDisposedException)
                 {
                     // ignored
-                    Logger.Info("Lock lost handler executed but cancellation token source was already disposed.", lockLostArgs.Exception);
+                    Logger.Info($"Lock lost handler executed for message with id '{messageId}' but cancellation token source was already disposed.", lockLostArgs.Exception);
                 }
             }
         }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -278,24 +278,22 @@
 
             try
             {
-                using (var azureServiceBusTransaction = CreateTransaction(message.PartitionKey))
-                {
-                    contextBag.Set(message);
-                    contextBag.Set(processMessageEventArgs);
+                using var azureServiceBusTransaction = CreateTransaction(message.PartitionKey);
+                contextBag.Set(message);
+                contextBag.Set(processMessageEventArgs);
 
-                    var messageContext = new MessageContext(messageId, headers, body,
-                        azureServiceBusTransaction.TransportTransaction, ReceiveAddress, contextBag);
+                var messageContext = new MessageContext(messageId, headers, body,
+                    azureServiceBusTransaction.TransportTransaction, ReceiveAddress, contextBag);
 
-                    await onMessage(messageContext, processingTokenSource.Token).ConfigureAwait(false);
+                await onMessage(messageContext, processingTokenSource.Token).ConfigureAwait(false);
 
-                    await processMessageEventArgs.SafeCompleteMessageAsync(message,
-                            transportSettings.TransportTransactionMode,
-                            azureServiceBusTransaction,
-                            cancellationToken: processingTokenSource.Token)
-                        .ConfigureAwait(false);
+                await processMessageEventArgs.SafeCompleteMessageAsync(message,
+                        transportSettings.TransportTransactionMode,
+                        azureServiceBusTransaction,
+                        cancellationToken: processingTokenSource.Token)
+                    .ConfigureAwait(false);
 
-                    azureServiceBusTransaction.Commit();
-                }
+                azureServiceBusTransaction.Commit();
             }
             catch (Exception ex) when (!ex.IsCausedBy(processingTokenSource.Token))
             {

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -273,7 +273,7 @@
             // to not flip the cancellation token until the very last moment in time when the stop token is flipped.
             var contextBag = new ContextBag();
             using var lockLostCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(messageProcessingCancellationToken);
-            CancellationToken lockLostCancellationToken = lockLostCancellationTokenSource.Token;
+            var lockLostCancellationToken = lockLostCancellationTokenSource.Token;
 
             processMessageEventArgs.MessageLockLostAsync += MessageLockLostHandler;
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -373,7 +373,7 @@
                 catch (ObjectDisposedException)
                 {
                     // ignored
-                    Logger.Info($"Lock lost handler executed for message with id '{messageId}' but cancellation token source was already disposed.", lockLostArgs.Exception);
+                    Logger.Debug($"Lock lost handler executed for message with id '{messageId}' but cancellation token source was already disposed.", lockLostArgs.Exception);
                 }
             }
         }


### PR DESCRIPTION
This PR leverages the feature that I contributed to the client library. The client library has the possibility to subscribe to message lock lost events. [When the message lock is lost, the message becomes available for consumption again
](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock)

> When a message is locked, other clients receiving from the same queue or subscription can take on locks and retrieve the next available messages not under active lock. When the lock on a message is explicitly released or when the lock expires, the message is placed at or near the front of the retrieval order for redelivery.

and attempts to settle the message will fail. See

> The Complete, DeadLetter, or RenewLock operations might fail due to network issues, if the held lock has expired, or there are other service-side conditions that prevent settlement. In one of the latter cases, the service sends a negative acknowledgment that surfaces as an exception in the API clients. If the reason is a broken network connection, the lock is dropped since Service Bus doesn't support recovery of existing AMQP links on a different connection.
> 
> If Complete fails, which occurs typically at the very end of message handling and in some cases after minutes of processing work, the receiving application can decide whether to preserve the state of the work and ignore the same message when it's delivered a second time, or whether to toss out the work result and retries as the message is redelivered.

the same applies for [Abandon](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver.abandonmessageasync?view=azure-dotnet)

> The lock for the message has expired or the message has already been completed. This does not apply for session-enabled entities. The [Reason](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusexception.reason?view=azure-dotnet#azure-messaging-servicebus-servicebusexception-reason) will be set to [MessageLockLost](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusfailurereason?view=azure-dotnet#azure-messaging-servicebus-servicebusfailurereason-messagelocklost) in this case.

While this mechanism only applies for the PeekLock Mode the client will simply not raise those events in the Receive-And-Delete mode.

By triggering the cancellation token that is eventually passed into Core when the message lock is lost this gives the clients that are forwarding the token the opportunity to abort their processing logic earlier since any attempts to eventually complete the message would throw a lock lost and the message would be retried anyway.
