### PR TITLE
Add LRU array and update exception handling for `receiveOnly`

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />

--- a/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
+    <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/CommandLineTests/NServiceBus.Transport.AzureServiceBus.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transport.AzureServiceBus.CommandLine.Tests.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.2.1" />

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NServiceBus" Version="9.2.2" />

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="Fody" Version="6.8.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -331,7 +331,7 @@
                 {
                     if (IsReceiveOnlyMessageLockLost(ex, message))
                     {
-                        Logger.Warn($"Message with id `{message.GetMessageId()}` has been returned to the queue and marked for deletion.  NServiceBus recoverability is being skipped. {ex.Message}");
+                        Logger.Warn($"Message with id `{message.GetMessageId()}` has been returned to the queue and marked for deletion on this endpoint instance.  NServiceBus recoverability is being skipped. {ex.Message}");
                         //Since the message lock was lost, we can't complete or abandon the message without throwing an error
                         //Recoverability should be skipped
                         return;
@@ -372,7 +372,7 @@
 
                     if (IsReceiveOnlyMessageLockLost(ex, message))
                     {
-                        Logger.Warn($"Message with id `{message.GetMessageId()}` has been returned to the queue and marked for deletion.- {onErrorEx.Message}");
+                        Logger.Warn($"Message with id `{message.GetMessageId()}` has been returned to the queue and marked for deletion. - {onErrorEx.Message}");
                         //Since the message lock was lost, we can't complete or abandon the message without throwing an error
                         return;
                     }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -368,13 +368,14 @@
                 }
                 catch (ServiceBusException onErrorEx) when (onErrorEx.IsTransient || onErrorEx.Reason is ServiceBusFailureReason.MessageLockLost)
                 {
+                    Logger.Debug("Failed to execute recoverability.", onErrorEx);
+
                     if (IsReceiveOnlyMessageLockLost(ex, message))
                     {
                         Logger.Warn($"Message with id `{message.GetMessageId()}` has been returned to the queue and marked for deletion.- {onErrorEx.Message}");
                         //Since the message lock was lost, we can't complete or abandon the message without throwing an error
                         return;
                     }
-                    Logger.Debug("Failed to execute recoverability.", onErrorEx);
 
                     await processMessageEventArgs.SafeAbandonMessageAsync(message,
                             transportSettings.TransportTransactionMode,

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" />

--- a/src/TransportTests/When_MessageLockLostException_is_thrown_from_process_message.cs
+++ b/src/TransportTests/When_MessageLockLostException_is_thrown_from_process_message.cs
@@ -13,7 +13,6 @@
         {
             bool onErrorCalled = false;
             var onMessageCalled = CreateTaskCompletionSource<bool>();
-            string criticalErrorDetails = null;
 
 
             await StartPump(
@@ -36,9 +35,11 @@
 
             await StopPump();
 
-            Assert.IsTrue(onMessageResult, "The message handler should have been called.");
-            Assert.IsFalse(onErrorCalled, "onError should not have been called when a MessageLostLock exception is thrown from onMessage when the transport is in receiveOnly mode.");
-            Assert.IsNull(criticalErrorDetails, $"Should not invoke critical error for {nameof(ServiceBusException)}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(onMessageResult, Is.True, "The message handler should have been called.");
+                Assert.That(onErrorCalled, Is.False, "onError should not have been called when a MessageLostLock exception is thrown from onMessage when the transport is in receiveOnly mode.");
+            });
         }
 
         [TestCase(TransportTransactionMode.None)]
@@ -47,8 +48,6 @@
         {
             bool onErrorCalled = false;
             var onMessageCalled = CreateTaskCompletionSource<bool>();
-            string criticalErrorDetails = null;
-
 
             await StartPump(
                 (_, __) =>
@@ -70,9 +69,11 @@
 
             await StopPump();
 
-            Assert.IsTrue(onMessageResult, "The message handler should have been called.");
-            Assert.IsTrue(onErrorCalled, "onError should have been called when a MessageLostLock exception is thrown from onMessage when the transport is not receiveOnly mode.");
-            Assert.IsNull(criticalErrorDetails, $"Should not invoke critical error for {nameof(ServiceBusException)}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(onMessageResult, Is.True, "The message handler should have been called.");
+                Assert.That(onErrorCalled, Is.True, "onError should have been called when a MessageLostLock exception is thrown from onMessage when the transport is not receiveOnly mode.");
+            });
         }
     }
 }

--- a/src/TransportTests/When_MessageLockLostException_is_thrown_from_process_message.cs
+++ b/src/TransportTests/When_MessageLockLostException_is_thrown_from_process_message.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.TransportTests
+{
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus;
+    using NServiceBus.TransportTests;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_MessageLockLostException_is_thrown_from_process_message : NServiceBusTransportTest
+    {
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        public async Task Should_not_throw_exception_from_on_error(TransportTransactionMode transactionMode)
+        {
+            bool onErrorCalled = false;
+            var onMessageCalled = CreateTaskCompletionSource<bool>();
+            string criticalErrorDetails = null;
+
+
+            await StartPump(
+                (_, __) =>
+                {
+                    onMessageCalled.TrySetResult(true);
+                    throw new ServiceBusException("from onMessage", ServiceBusFailureReason.MessageLockLost);
+                },
+                (_, __) =>
+                {
+                    onErrorCalled = true;
+                    throw new ServiceBusException("from onError", ServiceBusFailureReason.MessageLockLost);
+                },
+                transactionMode
+            );
+
+            await SendMessage(InputQueueName);
+
+            var onMessageResult = await onMessageCalled.Task.ConfigureAwait(false);
+
+            await StopPump();
+
+            Assert.IsTrue(onMessageResult, "The message handler should have been called.");
+            Assert.IsFalse(onErrorCalled, "onError should not have been called when a MessageLostLock exception is thrown from onMessage when the transport is in receiveOnly mode.");
+            Assert.IsNull(criticalErrorDetails, $"Should not invoke critical error for {nameof(ServiceBusException)}");
+        }
+
+        [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        public async Task Should_throw_exception_from_on_error(TransportTransactionMode transactionMode)
+        {
+            bool onErrorCalled = false;
+            var onMessageCalled = CreateTaskCompletionSource<bool>();
+            string criticalErrorDetails = null;
+
+
+            await StartPump(
+                (_, __) =>
+                {
+                    onMessageCalled.TrySetResult(true);
+                    throw new ServiceBusException("from onMessage", ServiceBusFailureReason.MessageLockLost);
+                },
+                (_, __) =>
+                {
+                    onErrorCalled = true;
+                    throw new ServiceBusException("from onError", ServiceBusFailureReason.MessageLockLost);
+                },
+                transactionMode
+            );
+
+            await SendMessage(InputQueueName);
+
+            var onMessageResult = await onMessageCalled.Task.ConfigureAwait(false);
+
+            await StopPump();
+
+            Assert.IsTrue(onMessageResult, "The message handler should have been called.");
+            Assert.IsTrue(onErrorCalled, "onError should have been called when a MessageLostLock exception is thrown from onMessage when the transport is not receiveOnly mode.");
+            Assert.IsNull(criticalErrorDetails, $"Should not invoke critical error for {nameof(ServiceBusException)}");
+        }
+    }
+}

--- a/src/TransportTests/When_MessageLockLostException_is_thrown_from_process_message.cs
+++ b/src/TransportTests/When_MessageLockLostException_is_thrown_from_process_message.cs
@@ -38,7 +38,7 @@
             Assert.Multiple(() =>
             {
                 Assert.That(onMessageResult, Is.True, "The message handler should have been called.");
-                Assert.That(onErrorCalled, Is.False, "onError should not have been called when a MessageLostLock exception is thrown from onMessage when the transport is in receiveOnly mode.");
+                Assert.That(onErrorCalled, Is.False, "onError should not have been called when a MessageLostLock exception is thrown from processMessage when the transport is in receiveOnly mode.");
             });
         }
 
@@ -72,7 +72,7 @@
             Assert.Multiple(() =>
             {
                 Assert.That(onMessageResult, Is.True, "The message handler should have been called.");
-                Assert.That(onErrorCalled, Is.True, "onError should have been called when a MessageLostLock exception is thrown from onMessage when the transport is not receiveOnly mode.");
+                Assert.That(onErrorCalled, Is.True, "onError should have been called when a MessageLostLock exception is thrown from processMessage when the transport is not receiveOnly mode.");
             });
         }
     }


### PR DESCRIPTION
This PR is a follow up related to:

- https://github.com/Particular/NServiceBus.AmazonSQS/issues/1926
- https://github.com/Particular/NServiceBus.AmazonSQS/pull/1861

### ✔ What has been done

- Added an LRU (least recently used) cache from the [BitFaster Caching](https://github.com/bitfaster/BitFaster.Caching) library 
- When using `receiveOnly`, skip `onError()` and normal recoverability process if message lost lock exception is detected when trying to safely complete the message.
- If message lock lost exception is detected during the `onError()` the `messageId` will be added to the LRU
- If the message is found in the LRU, but is not able to remove the message from the queue it remains in the LRU cache.
 
### 💭 Assumptions

Applies only to `receiveOnly`

- Should try and maintain consistency with other transports that have implemented LRU caching (e.g., RabittMQ, SQS and ASQ). 
- Don't want to stop the pipeline of a `recieveOnly` receiver when the message lock has expired to ensure that the handler successfully finishes.
- The `messageId` then should be added to the LRU when the handler has finished, and a message lock lost exception has been thrown.  This will mark the message for deletion so that the handler can be skipped, and the message can be removed from the queue when it is encountered by the receiver instance again.
- Normal recoverability process should be skipped because it requires a message lock to be active to be able to delete the message from the queue and send a copy to the error queue.  However, since the message lock lost exception was thrown, and the instance no longer has access to the message, the normal recoverability process can't be executed.

### ⏰ Time Complexity

The big-Θ is linear with respect to N and D/M

big-Θ (N * (ceil (D / M))) 

N = number of receiver instances that could handle the message
D = the time it takes for the handler to finish
M = the max message lock duration and max auto lock renewal

Example: 

N = 2 (number of instances)
D = 33 seconds
M = 5 seconds

ceil(33/5) = ceil(6.6) = 7
big-Θ (2 * 7) = big-Θ (14)

This indicates that in the worst-case scenario (big-Θ) across all the receiver instances, the handler could possibly execute 14 times before the message is finally removed from the queue. 

In the best-case scenario (big-Ω) using the same example above, we could get lucky, and the same instance could handle the message, and the other instance never sees it.  However, since the handler still takes longer than the message lock duration, the best-case would still only be big-Ω(7).  

This means that it's still important to make sure that the handler execution time is less than or equal to the message lock duration and renewal to reduce big-Θ.


