### PR TITLE
Track messages that successfully completed the message or error pipeline but failed to get acknowledged due to expired leases in receiveonly mode

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />

--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -14,9 +14,12 @@
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
+++ b/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
@@ -1,0 +1,109 @@
+﻿namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Azure.Messaging.ServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_message_visibility_expired : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_pipeline_successful()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(b =>
+                {
+                    b.CustomConfig(c =>
+                    {
+                        // Limiting the concurrency for this test to make sure messages that are made available again are 
+                        // not concurrently processed. This is not necessary for the test to pass but it makes
+                        // reasoning about the test easier.
+                        c.LimitMessageProcessingConcurrencyTo(1);
+                    });
+                    b.When((session, _) => session.SendLocal(new MyMessage()));
+                })
+                .Done(c => c.NativeMessageId is not null && c.Logs.Any(l => WasMarkedAsSuccessfullyCompleted(l, c)))
+                .Run();
+
+            var items = ctx.Logs.Where(l => WasMarkedAsSuccessfullyCompleted(l, ctx)).ToArray();
+
+            Assert.That(items, Is.Not.Empty);
+        }
+
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_error_pipeline_handled_the_message()
+        {
+            var ctx = await Scenario.Define<Context>(c =>
+                {
+                    c.ShouldThrow = true;
+                })
+                .WithEndpoint<Receiver>(b =>
+                {
+                    b.DoNotFailOnErrorMessages();
+                    b.CustomConfig(c =>
+                    {
+                        var recoverability = c.Recoverability();
+                        recoverability.AddUnrecoverableException<InvalidOperationException>();
+
+                        // Limiting the concurrency for this test to make sure messages that are made available again are 
+                        // not concurrently processed. This is not necessary for the test to pass but it makes
+                        // reasoning about the test easier.
+                        c.LimitMessageProcessingConcurrencyTo(1);
+                    });
+                    b.When((session, _) => session.SendLocal(new MyMessage()));
+                })
+                .Done(c => c.NativeMessageId is not null && c.Logs.Any(l => WasMarkedAsSuccessfullyCompleted(l, c)))
+                .Run();
+
+            var items = ctx.Logs.Where(l => WasMarkedAsSuccessfullyCompleted(l, ctx)).ToArray();
+
+            Assert.That(items, Is.Not.Empty);
+        }
+
+        static bool WasMarkedAsSuccessfullyCompleted(ScenarioContext.LogItem l, Context c)
+            => l.Message.StartsWith($"Received message with id '{c.NativeMessageId}' was marked as successfully completed");
+
+        class Context : ScenarioContext
+        {
+            public bool ShouldThrow { get; set; }
+
+            public string NativeMessageId { get; set; }
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServer>(c =>
+            {
+                var transport = c.ConfigureTransport<AzureServiceBusTransport>();
+                // Explicitly setting the transport transaction mode to ReceiveOnly because the message 
+                // tracking only is implemented for this mode.
+                transport.TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
+            });
+        }
+
+        public class MyMessage : IMessage;
+
+        class MyMessageHandler(Context testContext) : IHandleMessages<MyMessage>
+        {
+            public async Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                var messageEventArgs = context.Extensions.Get<ProcessMessageEventArgs>();
+                // By abandoning the message, the message will be "immediately available" for retrieval again and effectively the message pump
+                // has lost the message visibility timeout because any Complete or Abandon will be rejected by the azure service bus.
+                var serviceBusReceivedMessage = context.Extensions.Get<ServiceBusReceivedMessage>();
+                await messageEventArgs.AbandonMessageAsync(serviceBusReceivedMessage);
+
+                testContext.NativeMessageId = serviceBusReceivedMessage.MessageId;
+
+                if (testContext.ShouldThrow)
+                {
+                    throw new InvalidOperationException("Simulated exception");
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/FakeProcessor.cs
+++ b/src/Tests/FakeProcessor.cs
@@ -1,5 +1,8 @@
+#nullable enable
+
 namespace NServiceBus.Transport.AzureServiceBus.Tests
 {
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
@@ -21,7 +24,27 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             return Task.CompletedTask;
         }
 
-        public Task ProcessMessage(ServiceBusReceivedMessage message, ServiceBusReceiver receiver = null, CancellationToken cancellationToken = default)
-            => OnProcessMessageAsync(new ProcessMessageEventArgs(message, receiver ?? new FakeReceiver(), cancellationToken));
+        public Task ProcessMessage(ServiceBusReceivedMessage message, ServiceBusReceiver? receiver = null, CancellationToken cancellationToken = default)
+        {
+            var eventArgs = new CustomProcessMessageEventArgs(message, receiver ?? new FakeReceiver(), cancellationToken);
+            receivedMessageToEventArgs.Add(message, eventArgs);
+            return OnProcessMessageAsync(eventArgs);
+        }
+
+        readonly ConditionalWeakTable<ServiceBusReceivedMessage, CustomProcessMessageEventArgs>
+            receivedMessageToEventArgs = [];
+
+        sealed class CustomProcessMessageEventArgs : ProcessMessageEventArgs
+        {
+            public CustomProcessMessageEventArgs(ServiceBusReceivedMessage message, ServiceBusReceiver receiver, CancellationToken cancellationToken) : base(message, receiver, cancellationToken)
+            {
+            }
+
+            public CustomProcessMessageEventArgs(ServiceBusReceivedMessage message, ServiceBusReceiver receiver, string identifier, CancellationToken cancellationToken) : base(message, receiver, identifier, cancellationToken)
+            {
+            }
+
+            public Task RaiseMessageLockLost(MessageLockLostEventArgs args, CancellationToken cancellationToken = default) => OnMessageLockLostAsync(args);
+        }
     }
 }

--- a/src/Tests/FakeReceiver.cs
+++ b/src/Tests/FakeReceiver.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport.AzureServiceBus.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -9,12 +10,18 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
     {
         readonly List<(ServiceBusReceivedMessage, IDictionary<string, object> propertiesToModify)> abandonedMessages = [];
         readonly List<ServiceBusReceivedMessage> completedMessages = [];
+        readonly List<ServiceBusReceivedMessage> completingMessages = [];
+
+        public Func<ServiceBusReceivedMessage, CancellationToken, Task> CompleteMessageCallback = (_, _) => Task.CompletedTask;
 
         public IReadOnlyCollection<(ServiceBusReceivedMessage, IDictionary<string, object> propertiesToModify)> AbandonedMessages
             => abandonedMessages;
 
         public IReadOnlyCollection<ServiceBusReceivedMessage> CompletedMessages
             => completedMessages;
+
+        public IReadOnlyCollection<ServiceBusReceivedMessage> CompletingMessages
+            => completingMessages;
 
         public override Task AbandonMessageAsync(ServiceBusReceivedMessage message, IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default)
@@ -23,11 +30,12 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             return Task.CompletedTask;
         }
 
-        public override Task CompleteMessageAsync(ServiceBusReceivedMessage message,
+        public override async Task CompleteMessageAsync(ServiceBusReceivedMessage message,
             CancellationToken cancellationToken = default)
         {
+            completingMessages.Add(message);
+            await CompleteMessageCallback(message, cancellationToken);
             completedMessages.Add(message);
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="NServiceBus" Version="9.2.2" />
     <PackageReference Include="NServiceBus.Testing" Version="9.0.0" />
     <PackageReference Include="Particular.Approvals" Version="1.0.0" />

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NServiceBus" Version="9.2.2" />

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -13,15 +13,18 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NServiceBus" Version="9.2.2" />
     <PackageReference Include="NServiceBus.Testing" Version="9.0.0" />
+    <PackageReference Include="Particular.Approvals" Version="1.0.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Particular.Approvals" Version="1.0.0" />
-    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Receiving/MessagePumpTests.cs
+++ b/src/Tests/Receiving/MessagePumpTests.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
@@ -65,6 +66,142 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
                     .Matches<(ServiceBusReceivedMessage Message, IDictionary<string, object> Props)>(abandoned => abandoned.Message.MessageId == "SomeId"));
                 Assert.That(pumpWasCalled, Is.False);
             });
+        }
+
+        [Test]
+        public async Task Should_complete_message_on_next_receive_receiveonly_mode_when_pipeline_successful_but_completion_failed_due_to_expired_lease()
+        {
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+            var onMessageCalled = 0;
+            var onErrorCalled = 0;
+
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport { TransportTransactionMode = TransportTransactionMode.ReceiveOnly }, "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var pumpExecutingTaskCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            await using var _ = cancellationTokenSource.Token.Register(() => pumpExecutingTaskCompletionSource.TrySetCanceled());
+
+            await pump.Initialize(new PushRuntimeSettings(1), (_, _) =>
+                {
+                    onMessageCalled++;
+                    return Task.CompletedTask;
+                },
+                (_, _) =>
+                {
+                    onErrorCalled++;
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                }, CancellationToken.None);
+            await pump.StartReceive();
+
+            var firstReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+            var secondReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+
+            fakeReceiver.CompleteMessageCallback = (message, _) => message == firstReceivedMessage ?
+                Task.FromException(new ServiceBusException("Lock Lost", reason: ServiceBusFailureReason.MessageLockLost)) :
+                Task.CompletedTask;
+
+            var fakeProcessor = fakeClient.Processors["receiveAddress"];
+            await fakeProcessor.ProcessMessage(firstReceivedMessage, fakeReceiver);
+            await fakeProcessor.ProcessMessage(secondReceivedMessage, fakeReceiver);
+
+            Assert.That(fakeReceiver.CompletedMessages, Does.Not.Contain(firstReceivedMessage));
+            Assert.That(fakeReceiver.CompletedMessages, Does.Contain(secondReceivedMessage));
+            Assert.That(fakeReceiver.AbandonedMessages, Is.Empty);
+            Assert.That(onMessageCalled, Is.EqualTo(1));
+            Assert.That(onErrorCalled, Is.Zero);
+        }
+
+        [Test]
+        public async Task Should_abandon_message_in_atomic_mode_when_pipeline_successful_but_completion_failed_due_to_expired_lease()
+        {
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+            var onMessageCalled = 0;
+            var onErrorCalled = 0;
+
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport { TransportTransactionMode = TransportTransactionMode.SendsAtomicWithReceive }, "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var pumpExecutingTaskCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            await using var _ = cancellationTokenSource.Token.Register(() => pumpExecutingTaskCompletionSource.TrySetCanceled());
+
+            await pump.Initialize(new PushRuntimeSettings(1), (_, _) =>
+                {
+                    onMessageCalled++;
+                    return Task.CompletedTask;
+                },
+                (_, _) =>
+                {
+                    onErrorCalled++;
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                }, CancellationToken.None);
+            await pump.StartReceive();
+
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+
+            fakeReceiver.CompleteMessageCallback = (message, _) => message == receivedMessage ?
+                Task.FromException(new ServiceBusException("Lock Lost", reason: ServiceBusFailureReason.MessageLockLost)) :
+                Task.CompletedTask;
+
+            var fakeProcessor = fakeClient.Processors["receiveAddress"];
+            await fakeProcessor.ProcessMessage(receivedMessage, fakeReceiver);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fakeReceiver.AbandonedMessages.Select((tuple, _) => { var (message, _) = tuple; return message; })
+                    .ToList(), Does.Contain(receivedMessage));
+                Assert.That(fakeReceiver.CompletedMessages, Is.Empty);
+                Assert.That(onMessageCalled, Is.EqualTo(1));
+                Assert.That(onErrorCalled, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public async Task Should_complete_message_on_next_receive_receiveonly_mode_when_error_pipeline_successful_but_completion_failed_due_to_expired_lease()
+        {
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+            var onMessageCalled = 0;
+            var onErrorCalled = 0;
+
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport { TransportTransactionMode = TransportTransactionMode.ReceiveOnly }, "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var pumpExecutingTaskCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            await using var _ = cancellationTokenSource.Token.Register(() => pumpExecutingTaskCompletionSource.TrySetCanceled());
+
+            await pump.Initialize(new PushRuntimeSettings(1), (_, _) =>
+                {
+                    onMessageCalled++;
+                    return Task.FromException<InvalidOperationException>(new InvalidOperationException());
+                },
+                (_, _) =>
+                {
+                    onErrorCalled++;
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                }, CancellationToken.None);
+            await pump.StartReceive();
+
+            var firstReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+            var secondReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+
+            fakeReceiver.CompleteMessageCallback = (message, _) => message == firstReceivedMessage ?
+                Task.FromException(new ServiceBusException("Lock Lost", reason: ServiceBusFailureReason.MessageLockLost)) :
+                Task.CompletedTask;
+
+            var fakeProcessor = fakeClient.Processors["receiveAddress"];
+            await fakeProcessor.ProcessMessage(firstReceivedMessage, fakeReceiver);
+            await fakeProcessor.ProcessMessage(secondReceivedMessage, fakeReceiver);
+
+            Assert.That(fakeReceiver.CompletedMessages, Does.Not.Contain(firstReceivedMessage));
+            Assert.That(fakeReceiver.CompletedMessages, Does.Contain(secondReceivedMessage));
+            Assert.That(fakeReceiver.AbandonedMessages, Is.Empty);
+            Assert.That(onMessageCalled, Is.EqualTo(1));
+            Assert.That(onErrorCalled, Is.EqualTo(1));
         }
 
         [Test]

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.18.1, 8.0.0)" />
-    <PackageReference Include="BitFaster.Caching" Version="[2.5.1, 3.0.0)" />
+    <PackageReference Include="BitFaster.Caching" Version="[2.5.2, 3.0.0)" />
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
   </ItemGroup>
 

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.18.1, 8.0.0)" />
-    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="BitFaster.Caching" Version="[2.5.1, 3.0.0)" />
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
   </ItemGroup>
 

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.18.1, 8.0.0)" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
   </ItemGroup>
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -306,11 +306,7 @@
                             cancellationToken: messageProcessingCancellationToken)
                         .ConfigureAwait(false);
                 }
-                catch (Exception onErrorEx) when (onErrorEx.IsCausedBy(messageProcessingCancellationToken))
-                {
-                    throw;
-                }
-                catch (Exception onErrorEx)
+                catch (Exception onErrorEx) when (!onErrorEx.IsCausedBy(messageProcessingCancellationToken))
                 {
                     criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{message.MessageId}`", onErrorEx, messageProcessingCancellationToken);
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -139,14 +139,14 @@
 
                 // Deliberately not using the cancellation token to make sure we abandon the message even when the
                 // cancellation token is already set.
-                if (await arg.TrySafeCompleteMessageAsync(message, transportSettings.TransportTransactionMode, messagesToBeCompleted, CancellationToken.None).ConfigureAwait(false))
+                if (await arg.TrySafeCompleteMessage(message, transportSettings.TransportTransactionMode, messagesToBeCompleted, CancellationToken.None).ConfigureAwait(false))
                 {
                     return;
                 }
 
                 // Deliberately not using the cancellation token to make sure we abandon the message even when the
                 // cancellation token is already set.
-                if (await arg.TrySafeAbandonMessageAsync(message, transportSettings.TransportTransactionMode, CancellationToken.None).ConfigureAwait(false))
+                if (await arg.TrySafeAbandonMessage(message, transportSettings.TransportTransactionMode, CancellationToken.None).ConfigureAwait(false))
                 {
                     return;
                 }
@@ -156,7 +156,7 @@
             }
             catch (Exception ex)
             {
-                await arg.SafeDeadLetterMessageAsync(message, transportSettings.TransportTransactionMode, ex, CancellationToken.None).ConfigureAwait(false);
+                await arg.SafeDeadLetterMessage(message, transportSettings.TransportTransactionMode, ex, CancellationToken.None).ConfigureAwait(false);
 
                 return;
             }
@@ -254,7 +254,7 @@
 
                 await onMessage(messageContext, messageProcessingCancellationToken).ConfigureAwait(false);
 
-                await processMessageEventArgs.SafeCompleteMessageAsync(message,
+                await processMessageEventArgs.SafeCompleteMessage(message,
                         transportSettings.TransportTransactionMode,
                         azureServiceBusTransaction,
                         messagesToBeCompleted,
@@ -278,7 +278,7 @@
 
                         if (result == ErrorHandleResult.Handled)
                         {
-                            await processMessageEventArgs.SafeCompleteMessageAsync(message,
+                            await processMessageEventArgs.SafeCompleteMessage(message,
                                     transportSettings.TransportTransactionMode,
                                     azureServiceBusTransaction,
                                     messagesToBeCompleted,
@@ -291,7 +291,7 @@
 
                     if (result == ErrorHandleResult.RetryRequired)
                     {
-                        await processMessageEventArgs.SafeAbandonMessageAsync(message,
+                        await processMessageEventArgs.SafeAbandonMessage(message,
                                 transportSettings.TransportTransactionMode,
                                 cancellationToken: messageProcessingCancellationToken)
                             .ConfigureAwait(false);
@@ -301,7 +301,7 @@
                 {
                     Logger.Debug("Failed to execute recoverability.", onErrorEx);
 
-                    await processMessageEventArgs.SafeAbandonMessageAsync(message,
+                    await processMessageEventArgs.SafeAbandonMessage(message,
                             transportSettings.TransportTransactionMode,
                             cancellationToken: messageProcessingCancellationToken)
                         .ConfigureAwait(false);
@@ -314,7 +314,7 @@
                 {
                     criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{message.MessageId}`", onErrorEx, messageProcessingCancellationToken);
 
-                    await processMessageEventArgs.SafeAbandonMessageAsync(message,
+                    await processMessageEventArgs.SafeAbandonMessage(message,
                             transportSettings.TransportTransactionMode,
                             cancellationToken: messageProcessingCancellationToken)
                         .ConfigureAwait(false);

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -300,7 +300,7 @@
                             .ConfigureAwait(false);
                     }
                 }
-                catch (ServiceBusException onErrorEx) when (onErrorEx.IsTransient)
+                catch (ServiceBusException onErrorEx) when (onErrorEx.IsTransient || onErrorEx.Reason == ServiceBusFailureReason.MessageLockLost)
                 {
                     Logger.Debug("Failed to execute recoverability.", onErrorEx);
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -97,14 +97,9 @@
                     criticalErrorAction("Failed to receive message from Azure Service Bus.", ex,
                         messageProcessingCancellationTokenSource.Token);
                 }, () =>
-                {
                     //We don't have to update the prefetch count since we are failing to receive anyway
-                    processor.UpdateConcurrency(1);
-                },
-                () =>
-                {
-                    processor.UpdateConcurrency(limitations.MaxConcurrency);
-                });
+                    processor.UpdateConcurrency(1),
+                () => processor.UpdateConcurrency(limitations.MaxConcurrency));
 
             await processor.StartProcessingAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Transport/Receiving/ProcessMessageEventArgsExtensions.cs
+++ b/src/Transport/Receiving/ProcessMessageEventArgsExtensions.cs
@@ -1,29 +1,140 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
+    using BitFaster.Caching;
+    using Logging;
 
     static class ProcessMessageEventArgsExtensions
     {
+        public static async ValueTask<bool> TrySafeCompleteMessageAsync(this ProcessMessageEventArgs args,
+            ServiceBusReceivedMessage message, TransportTransactionMode transportTransactionMode,
+            ICache<string, bool> messagesToBeCompleted,
+            CancellationToken cancellationToken = default)
+        {
+            if (transportTransactionMode == TransportTransactionMode.ReceiveOnly && messagesToBeCompleted.TryGet(message.GetMessageId(), out _))
+            {
+                Logger.DebugFormat("Received message with id '{0}' was marked as successfully completed. Trying to immediately acknowledge the message without invoking the pipeline.", message.GetMessageId());
+
+                try
+                {
+                    await args.CompleteMessageAsync(message, cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
+                    return true;
+                }
+                // Doing a more generous catch here to make sure we are not losing the ID and can mark it to be completed another time
+                catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
+                {
+                    messagesToBeCompleted.AddOrUpdate(message.GetMessageId(), true);
+                    throw;
+                }
+            }
+            return false;
+        }
+
+        public static async ValueTask<bool> TrySafeAbandonMessageAsync(this ProcessMessageEventArgs args,
+            ServiceBusReceivedMessage message, TransportTransactionMode transportTransactionMode,
+            CancellationToken cancellationToken = default)
+        {
+            // TransportTransactionMode.None uses ReceiveAndDelete mode which means the message is already removed from the queue
+            // once we get it. Therefore, we don't need to abandon it.
+            if (transportTransactionMode != TransportTransactionMode.None && message.LockedUntil < DateTimeOffset.UtcNow)
+            {
+                Logger.Warn(
+                    $"Skip handling the message with id '{message.GetMessageId()}' because the lock has expired at '{message.LockedUntil}'. " +
+                    "This is usually an indication that the endpoint prefetches more messages than it is able to handle within the configured" +
+                    " peek lock duration. Consider tweaking the prefetch configuration to values that are better aligned with the concurrency" +
+                    " of the endpoint and the time it takes to handle the messages.");
+
+                try
+                {
+                    await args.SafeAbandonMessageAsync(message, transportTransactionMode, cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
+                    return true;
+                }
+                catch (Exception e) when (!e.IsCausedBy(cancellationToken))
+                {
+                    // nothing we can do about it, message will be retried
+                    Logger.Debug($"Error abandoning the message with id '{message.GetMessageId()}' because the lock has expired at '{message.LockedUntil}.", e);
+                }
+            }
+            return false;
+        }
+
+        public static async Task SafeDeadLetterMessageAsync(this ProcessMessageEventArgs args, ServiceBusReceivedMessage message,
+            TransportTransactionMode transportTransactionMode, Exception exception, CancellationToken cancellationToken = default)
+        {
+            if (transportTransactionMode != TransportTransactionMode.None)
+            {
+                Logger.Warn($"Poison message detected. Message will be moved to the poison queue. Exception: {exception.Message}", exception);
+
+                try
+                {
+                    await args.DeadLetterMessageAsync(message,
+                            deadLetterReason: "Poisoned message",
+                            deadLetterErrorDescription: exception.Message,
+                            cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception deadLetterEx) when (!deadLetterEx.IsCausedBy(cancellationToken))
+                {
+                    // nothing we can do about it, message will be retried
+                    Logger.Debug("Error dead lettering poisoned message.", deadLetterEx);
+                }
+            }
+            else
+            {
+                Logger.Warn($"Poison message detected. Message will be discarded, transaction mode is set to None. Exception: {exception.Message}", exception);
+            }
+        }
+
         public static async Task SafeCompleteMessageAsync(this ProcessMessageEventArgs args,
             ServiceBusReceivedMessage message, TransportTransactionMode transportTransactionMode,
             AzureServiceBusTransportTransaction azureServiceBusTransaction,
+            ICache<string, bool> messagesToBeCompleted,
             CancellationToken cancellationToken = default)
         {
             if (transportTransactionMode != TransportTransactionMode.None)
             {
-                using var scope = azureServiceBusTransaction.ToTransactionScope();
-                await args.CompleteMessageAsync(message, cancellationToken).ConfigureAwait(false);
-
-                scope.Complete();
+                try
+                {
+                    using var scope = azureServiceBusTransaction.ToTransactionScope();
+                    await args.CompleteMessageAsync(message, cancellationToken).ConfigureAwait(false);
+                    scope.Complete();
+                }
+                catch (ServiceBusException e) when (transportTransactionMode == TransportTransactionMode.ReceiveOnly && e.Reason == ServiceBusFailureReason.MessageLockLost)
+                {
+                    // We tried to complete the message because it was successfully either by the pipeline or recoverability, but the lock was lost.
+                    // To make sure we are not reprocessing it unnecessarily we are tracking the message ID and will complete it
+                    // on the next receive. For SendsWithAtomicReceive it is necessary to throw which causes the rollback
+                    // of the transaction and will trigger recoverability.
+                    messagesToBeCompleted.AddOrUpdate(message.GetMessageId(), true);
+                }
             }
         }
 
-        public static Task SafeAbandonMessageAsync(this ProcessMessageEventArgs args, ServiceBusReceivedMessage message,
+        public static async Task SafeAbandonMessageAsync(this ProcessMessageEventArgs args, ServiceBusReceivedMessage message,
             TransportTransactionMode transportTransactionMode, CancellationToken cancellationToken = default)
-            => transportTransactionMode != TransportTransactionMode.None
-                ? args.AbandonMessageAsync(message, cancellationToken: cancellationToken)
-                : Task.CompletedTask;
+        {
+            if (transportTransactionMode != TransportTransactionMode.None)
+            {
+                try
+                {
+                    await args.AbandonMessageAsync(message, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.MessageLockLost)
+                {
+                    // We tried to abandon the message because it needs to be retried, but the lock was lost.
+                    // the message will reappear on the next receive anyway so we can just ignore this case.
+                    Logger.DebugFormat("Attempted to abandon the message with id '{0}' but the lock was lost.", message.GetMessageId());
+                }
+            }
+        }
+
+        // The extension methods here are related to functionality of the message pump. Therefore the same logger name
+        // is used as the message pump.
+        static readonly ILog Logger = LogManager.GetLogger<MessagePump>();
     }
 }

--- a/src/Transport/Receiving/ProcessMessageEventArgsExtensions.cs
+++ b/src/Transport/Receiving/ProcessMessageEventArgsExtensions.cs
@@ -9,7 +9,7 @@
 
     static class ProcessMessageEventArgsExtensions
     {
-        public static async ValueTask<bool> TrySafeCompleteMessageAsync(this ProcessMessageEventArgs args,
+        public static async ValueTask<bool> TrySafeCompleteMessage(this ProcessMessageEventArgs args,
             ServiceBusReceivedMessage message, TransportTransactionMode transportTransactionMode,
             ICache<string, bool> messagesToBeCompleted,
             CancellationToken cancellationToken = default)
@@ -34,7 +34,7 @@
             return false;
         }
 
-        public static async ValueTask<bool> TrySafeAbandonMessageAsync(this ProcessMessageEventArgs args,
+        public static async ValueTask<bool> TrySafeAbandonMessage(this ProcessMessageEventArgs args,
             ServiceBusReceivedMessage message, TransportTransactionMode transportTransactionMode,
             CancellationToken cancellationToken = default)
         {
@@ -50,7 +50,7 @@
 
                 try
                 {
-                    await args.SafeAbandonMessageAsync(message, transportTransactionMode, cancellationToken: cancellationToken)
+                    await args.SafeAbandonMessage(message, transportTransactionMode, cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                     return true;
                 }
@@ -63,7 +63,7 @@
             return false;
         }
 
-        public static async Task SafeDeadLetterMessageAsync(this ProcessMessageEventArgs args, ServiceBusReceivedMessage message,
+        public static async Task SafeDeadLetterMessage(this ProcessMessageEventArgs args, ServiceBusReceivedMessage message,
             TransportTransactionMode transportTransactionMode, Exception exception, CancellationToken cancellationToken = default)
         {
             if (transportTransactionMode != TransportTransactionMode.None)
@@ -90,7 +90,7 @@
             }
         }
 
-        public static async Task SafeCompleteMessageAsync(this ProcessMessageEventArgs args,
+        public static async Task SafeCompleteMessage(this ProcessMessageEventArgs args,
             ServiceBusReceivedMessage message, TransportTransactionMode transportTransactionMode,
             AzureServiceBusTransportTransaction azureServiceBusTransaction,
             ICache<string, bool> messagesToBeCompleted,
@@ -115,7 +115,7 @@
             }
         }
 
-        public static async Task SafeAbandonMessageAsync(this ProcessMessageEventArgs args, ServiceBusReceivedMessage message,
+        public static async Task SafeAbandonMessage(this ProcessMessageEventArgs args, ServiceBusReceivedMessage message,
             TransportTransactionMode transportTransactionMode, CancellationToken cancellationToken = default)
         {
             if (transportTransactionMode != TransportTransactionMode.None)

--- a/src/Transport/Utilities/TransactionExtensions.cs
+++ b/src/Transport/Utilities/TransactionExtensions.cs
@@ -1,14 +1,14 @@
-﻿namespace NServiceBus.Transport.AzureServiceBus
+﻿#nullable enable
+
+namespace NServiceBus.Transport.AzureServiceBus
 {
     using System.Transactions;
 
     static class TransactionExtensions
     {
-        public static TransactionScope ToScope(this Transaction transaction)
-        {
-            return transaction != null
+        public static TransactionScope ToScope(this Transaction? transaction) =>
+            transaction != null
                 ? new TransactionScope(transaction, TransactionScopeAsyncFlowOption.Enabled)
                 : new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
-        }
     }
 }

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -11,9 +11,12 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" GeneratePathProperty="true" />


### PR DESCRIPTION
This PR follows through on related changes done in [Amazon SQS](https://github.com/Particular/NServiceBus.AmazonSQS/pull/1861) but adjusts the core pieces of the change to Azure Service Bus-specific behavior. Additionally, it brings in a number of layered tests that verify the code works as expected and doesn't accidentally break later.

An LRU cache to track the delivery attempts is not necessary because the receive count is automatically updated by the storage queue infrastructure.

The changes have only been applied for the **receive only** transaction mode because with the sends-atomic receive mode the outgoing messages are enlisted with a send-via information together with the incoming message. The outgoing messages are only sent when the incoming message successfully completed. In cases when the incoming message wasn't successfully completed, the outgoing operations are discarded by the broker and there is no way to refer to outgoing operations of a previous message handling attempt.

- Caching Acknowledged Messages: A cache (using `BitFaster.Caching.Lru`) is introduced to keep track of messages that have been marked as successfully completed. This helps in avoiding unnecessary retries for messages that are already acknowledged.
- Error Handling Improvements: Enhanced handling around retries and error recovery, including better logging and recovery actions for different failure scenarios.
- Minor cleanups such as removing the async suffix or making the abandon actually safe.

## Before ReceiveOnly

```mermaid
graph TD
    A[Receive Message] --> B[Invoke OnMessage]
    B --> C{Success?}
    C -- Yes --> D[Acknowledge message]
    D --> E[Message acknowledged]  
    C -- No --> F[Invoke OnError]
    F --> G{Error requires retry?}
    G -- Yes --> H[Requeue message]
    G -- No --> I[Acknowledge message]
    H --> J[Message requeued]
    I --> E[Message acknowledged]
```

## After ReceiveOnly

```mermaid
graph TD
    A[Receive Message] --> B[ID in LRU]
    B -- Yes --> M[Acknowledge message]
    F --> G[Message tracked]
    B -- No --> H[Invoke OnMessage]
    H --> I{Success?}
    I -- Yes --> M
    I -- No --> J[Invoke OnError]
    J --> K{Error requires retry?}
    K -- Yes --> L[Requeue message]
    K -- No --> M[Acknowledge message]
    M --> N{Ack success?}
    N -- Yes --> E[Message acknowledged]
    N -- No --> F[Track ID in LRU]
    G -- Message requeued --> A
```

## Tradeoffs

The tradeoffs are the sames as the other fixes applied in RabbitMQ and Amazon SQS. In competing consumer scenarios there can still be more retries because the LRU cache is in memory, but it is still marginally better than having a potentially unlimited number of retries. 

As for the transaction mode `None`, there is no change required since we are not giving any guarantees there and messages are acknowledged early on with `ReceiveAndDelete`.

Ideally at some point, if the complexity grows further, it would be good to split the pump into different receive strategies. Given the message settlement operations already had specific code around transport transaction modes and the risk of doing such a split is high a decision was made to not introduce a receive strategy and treat the settlement operation extensions as closesly related to the pump (hence they share the same logger)