### PR TITLE
Inline dispatching of individual sends for messages that are too large to fit into a batch

### DIFF
--- a/src/Tests/FakeSender.cs
+++ b/src/Tests/FakeSender.cs
@@ -27,27 +27,27 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             set => throw new NotSupportedException();
         }
 
-        public override ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default)
+        public override async ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default)
         {
             var batchMessageStore = new List<ServiceBusMessage>();
             ServiceBusMessageBatch serviceBusMessageBatch = ServiceBusModelFactory.ServiceBusMessageBatch(256 * 1024, batchMessageStore, tryAddCallback: TryAdd);
             batchToBackingStore.Add(serviceBusMessageBatch, batchMessageStore);
-            return new ValueTask<ServiceBusMessageBatch>(
-                serviceBusMessageBatch);
+            await Task.Yield();
+            return serviceBusMessageBatch;
         }
 
-        public override Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
+        public override async Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             sentMessages.Add(message);
-            return Task.CompletedTask;
+            await Task.Yield();
         }
 
-        public override Task SendMessagesAsync(ServiceBusMessageBatch messageBatch, CancellationToken cancellationToken = default)
+        public override async Task SendMessagesAsync(ServiceBusMessageBatch messageBatch, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             batchedMessages.Add(messageBatch);
-            return Task.CompletedTask;
+            await Task.Yield();
         }
     }
 }


### PR DESCRIPTION
Fixes #1048

[Previous test run of first commit before rebase that reproduced the problem](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/actions/runs/11017750455)

I think as a follow-up PR for master it might make sense to tone down slightly the overly clever trickery that fell apart when we introduced the collecting of too large messages, but I figured these structural changes should be done outside the realm of fixing the bug.