### PR TITLE
Inline dispatching of individual sends for messages that are too large to fit into a batch

### DIFF
--- a/src/Tests/FakeSender.cs
+++ b/src/Tests/FakeSender.cs
@@ -27,27 +27,27 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             set => throw new NotSupportedException();
         }
 
-        public override ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default)
+        public override async ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default)
         {
             var batchMessageStore = new List<ServiceBusMessage>();
             ServiceBusMessageBatch serviceBusMessageBatch = ServiceBusModelFactory.ServiceBusMessageBatch(256 * 1024, batchMessageStore, tryAddCallback: TryAdd);
             batchToBackingStore.Add(serviceBusMessageBatch, batchMessageStore);
-            return new ValueTask<ServiceBusMessageBatch>(
-                serviceBusMessageBatch);
+            await Task.Yield();
+            return serviceBusMessageBatch;
         }
 
-        public override Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
+        public override async Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             sentMessages.Add(message);
-            return Task.CompletedTask;
+            await Task.Yield();
         }
 
-        public override Task SendMessagesAsync(ServiceBusMessageBatch messageBatch, CancellationToken cancellationToken = default)
+        public override async Task SendMessagesAsync(ServiceBusMessageBatch messageBatch, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             batchedMessages.Add(messageBatch);
-            return Task.CompletedTask;
+            await Task.Yield();
         }
     }
 }


### PR DESCRIPTION
* Backports https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1049 to release branch `release-4.2` to fix https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/1048 in version 4.2.1.

Commits:
* Yield in FakeSender to expose any assumptions we might be making around things happening on the synchronous path
* Fix the problem of not having the individual sends being properly tracked by inlining the dispatching the individual sends. Rename the method for better clarity