### PR TITLE
Simplify dispatcher

### DIFF
--- a/src/Tests/FakeSender.cs
+++ b/src/Tests/FakeSender.cs
@@ -27,27 +27,26 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests
             set => throw new NotSupportedException();
         }
 
-        public override async ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default)
+        public override ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default)
         {
             var batchMessageStore = new List<ServiceBusMessage>();
             ServiceBusMessageBatch serviceBusMessageBatch = ServiceBusModelFactory.ServiceBusMessageBatch(256 * 1024, batchMessageStore, tryAddCallback: TryAdd);
             batchToBackingStore.Add(serviceBusMessageBatch, batchMessageStore);
-            await Task.Yield();
-            return serviceBusMessageBatch;
+            return new ValueTask<ServiceBusMessageBatch>(serviceBusMessageBatch);
         }
 
-        public override async Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
+        public override Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             sentMessages.Add(message);
-            await Task.Yield();
+            return Task.CompletedTask;
         }
 
-        public override async Task SendMessagesAsync(ServiceBusMessageBatch messageBatch, CancellationToken cancellationToken = default)
+        public override Task SendMessagesAsync(ServiceBusMessageBatch messageBatch, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             batchedMessages.Add(messageBatch);
-            await Task.Yield();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -44,7 +44,6 @@ namespace NServiceBus.Transport.AzureServiceBus
             Dictionary<string, List<IOutgoingTransportOperation>>? defaultOperationsPerDestination = null;
             var numberOfDefaultOperations = 0;
             var numberOfIsolatedOperations = 0;
-            var numberOfDefaultOperationDestinations = 0;
 
             foreach (var operation in transportOperations)
             {
@@ -59,8 +58,6 @@ namespace NServiceBus.Transport.AzureServiceBus
                         if (!defaultOperationsPerDestination.ContainsKey(destination))
                         {
                             defaultOperationsPerDestination[destination] = [operation];
-                            // because we batch only the number of destinations are relevant
-                            numberOfDefaultOperationDestinations++;
                         }
                         else
                         {
@@ -91,14 +88,12 @@ namespace NServiceBus.Transport.AzureServiceBus
                 throw new Exception($"The number of outgoing messages ({numberOfDefaultOperations}) exceeds the limits permitted by Azure Service Bus ({MaxMessageThresholdForTransaction}) in a single transaction");
             }
 
-            var concurrentDispatchTasks =
-                new List<Task>(numberOfIsolatedOperations + numberOfDefaultOperationDestinations);
-            AddIsolatedOperationsTo(concurrentDispatchTasks, isolatedOperationsPerDestination ?? emptyDestinationAndOperations, transaction, azureServiceBusTransaction, cancellationToken);
-            AddBatchedOperationsTo(concurrentDispatchTasks, defaultOperationsPerDestination ?? emptyDestinationAndOperations, transaction, azureServiceBusTransaction, cancellationToken);
+            var isolatedOperationsTask = AddIsolatedOperationsTo(isolatedOperationsPerDestination ?? emptyDestinationAndOperations, numberOfIsolatedOperations, transaction, azureServiceBusTransaction, cancellationToken);
+            var batchedOperationsTask = AddBatchedOperationsTo(defaultOperationsPerDestination ?? emptyDestinationAndOperations, numberOfDefaultOperations, transaction, azureServiceBusTransaction, cancellationToken);
 
             try
             {
-                await Task.WhenAll(concurrentDispatchTasks).ConfigureAwait(false);
+                await Task.WhenAll(isolatedOperationsTask, batchedOperationsTask).ConfigureAwait(false);
             }
             catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
@@ -109,11 +104,18 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         // The parameters of this method are deliberately mutable and of the original collection type to make sure
         // no boxing occurs
-        void AddBatchedOperationsTo(List<Task> dispatchTasks,
+        Task AddBatchedOperationsTo(
             Dictionary<string, List<IOutgoingTransportOperation>> transportOperationsPerDestination,
+            int numberOfTransportOperations,
             TransportTransaction transportTransaction,
             AzureServiceBusTransportTransaction? azureServiceBusTransportTransaction, CancellationToken cancellationToken)
         {
+            if (numberOfTransportOperations == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            var dispatchTasks = new List<Task>(transportOperationsPerDestination.Count);
             foreach (var destinationAndOperations in transportOperationsPerDestination)
             {
                 var destination = destinationAndOperations.Key;
@@ -127,9 +129,12 @@ namespace NServiceBus.Transport.AzureServiceBus
                     messagesToSend.Enqueue(message);
                 }
                 // Accessing azureServiceBusTransaction.CommittableTransaction will initialize it if it isn't yet
-                // doing the access as late as possible but still on the synchronous path.
+                // doing the access as late as possible but still on the synchronous path. Initializing the transaction
+                // as late as possible is important because it will start the transaction timer. If the transaction
+                // is started too early it might shorten the overall transaction time available.
                 dispatchTasks.Add(DispatchBatchOrFallbackToIndividualSendsForDestination(destination, azureServiceBusTransportTransaction?.ServiceBusClient, azureServiceBusTransportTransaction?.Transaction, messagesToSend, cancellationToken));
             }
+            return Task.WhenAll(dispatchTasks);
         }
 
         async Task DispatchBatchOrFallbackToIndividualSendsForDestination(string destination, ServiceBusClient? client, Transaction? transaction,
@@ -230,16 +235,23 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         // The parameters of this method are deliberately mutable and of the original collection type to make sure
         // no boxing occurs
-        void AddIsolatedOperationsTo(List<Task> dispatchTasks,
+        Task AddIsolatedOperationsTo(
             Dictionary<string, List<IOutgoingTransportOperation>> transportOperationsPerDestination,
+            int numberOfTransportOperations,
             TransportTransaction transportTransaction,
             AzureServiceBusTransportTransaction? azureServiceBusTransportTransaction,
             CancellationToken cancellationToken)
         {
+            if (numberOfTransportOperations == 0)
+            {
+                return Task.CompletedTask;
+            }
+
             // It is OK to use the pumps client and partition key (keeps things compliant as before) but
             // isolated dispatches should never use the committable transaction regardless whether it is present
             // or not.
             Transaction? noTransaction = default;
+            var dispatchTasks = new List<Task>(numberOfTransportOperations);
             foreach (var destinationAndOperations in transportOperationsPerDestination)
             {
                 var destination = destinationAndOperations.Key;
@@ -252,6 +264,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                     dispatchTasks.Add(DispatchForDestination(destination, azureServiceBusTransportTransaction?.ServiceBusClient, noTransaction, message, cancellationToken));
                 }
             }
+            return Task.WhenAll(dispatchTasks);
         }
 
         async Task DispatchForDestination(string destination, ServiceBusClient? client, Transaction? transaction, ServiceBusMessage message, CancellationToken cancellationToken)

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -90,8 +90,8 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             Task[] dispatchTasks =
             [
-                AddIsolatedOperationsTo(isolatedOperationsPerDestination ?? emptyDestinationAndOperations, numberOfIsolatedOperations, transaction, azureServiceBusTransaction, cancellationToken),
-                AddBatchedOperationsTo(defaultOperationsPerDestination ?? emptyDestinationAndOperations, numberOfDefaultOperations, transaction, azureServiceBusTransaction, cancellationToken)
+                DispatchIsolatedOperations(isolatedOperationsPerDestination ?? emptyDestinationAndOperations, numberOfIsolatedOperations, transaction, azureServiceBusTransaction, cancellationToken),
+                DispatchBatchedOperations(defaultOperationsPerDestination ?? emptyDestinationAndOperations, numberOfDefaultOperations, transaction, azureServiceBusTransaction, cancellationToken)
             ];
 
             try
@@ -107,7 +107,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         // The parameters of this method are deliberately mutable and of the original collection type to make sure
         // no boxing occurs
-        Task AddBatchedOperationsTo(
+        Task DispatchBatchedOperations(
             Dictionary<string, List<IOutgoingTransportOperation>> transportOperationsPerDestination,
             int numberOfTransportOperations,
             TransportTransaction transportTransaction,
@@ -238,7 +238,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
         // The parameters of this method are deliberately mutable and of the original collection type to make sure
         // no boxing occurs
-        Task AddIsolatedOperationsTo(
+        Task DispatchIsolatedOperations(
             Dictionary<string, List<IOutgoingTransportOperation>> transportOperationsPerDestination,
             int numberOfTransportOperations,
             TransportTransaction transportTransaction,


### PR DESCRIPTION
Follow through on #1049 

This attempts to simplify the dispatcher a bit where possible to no longer rely on the synchronous path. This PR attempts to find a good balance between allocating the necessary task lists with the number of items needed because that is beneficial compared to doing `Task.WhenAll` with `Select` and `ToArray`

![image](https://github.com/user-attachments/assets/ec506197-f026-4384-b6a5-32f7ce0a5738)

During the discussion with @andreasohlund and @PhilBastian we concluded the original problem would only really have been discovered if the following are true:

- Premium namespace (we don't use a premium namespace yet in our CI/CD environment)
- The underlying SDK cannot yet have cached the batch size information of the underlying AMQP link (will make the `CreateMessageBatchAsync` yield) or the large message has to be put into a batch that is sent after the first batch was dispatched

Given that we have not even the premium namespace in place currently, simplifying the dispatcher slightly to avoid such an error seems to be warranted.

I have also removed the yielding, since that was just a way to reproduce the previous problem. With the new structure this is no longer necessary.