### PR TITLE
Fix thread-safe comparison used to optimize circuit breaker's Success method

### DIFF
--- a/src/Transport/Receiving/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/src/Transport/Receiving/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -29,6 +29,7 @@
                 return;
             }
 
+            Volatile.Write(ref failureCount, 0);
             timer.Change(Timeout.Infinite, Timeout.Infinite);
             Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
             disarmedAction();

--- a/src/Transport/Receiving/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/src/Transport/Receiving/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -23,9 +23,8 @@
 
         public void Success()
         {
-            var oldValue = Interlocked.Exchange(ref failureCount, 0);
-
-            if (oldValue == 0)
+            // If the failure count was already zero, replace it with zero (no change) and then return original
+            if (Interlocked.CompareExchange(ref failureCount, 0, 0) == 0)
             {
                 return;
             }


### PR DESCRIPTION
The circuit breaker's Success() method must be as close to a no-op as possible on the happy path, but when disarming in a multi-threaded environment still needs to run the disarm logic only once.

Previously, while querying values was done in a thread-safe way, a thread on the Failure method could pause while a Success() call ran to entirety, setting the failure count to 0, and ensuring that further calls to Success() would see a failure count of 0 and take no action, even though the arming action had been executed most recently.

This resulted in a scenario where no number of Success calls could undo the armedAction, unless another Failure call went first.