### PR TITLE
Address races in the repeated failure circuit breaker by introducing explicit state transitions

### DIFF
--- a/src/Transport/Receiving/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/src/Transport/Receiving/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -45,7 +45,7 @@
             {
                 armedAction();
                 _ = timer.Change(timeToWaitBeforeTriggering, NoPeriodicTriggering);
-                Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
+                Logger.WarnFormat("The circuit breaker for {0} is now in the armed state due to {1}", name, exception);
             }
 
             // If the circuit breaker has been triggered, wait for 10 seconds before proceeding to prevent flooding the logs and hammering the ServiceBus
@@ -61,7 +61,7 @@
                 return;
             }
 
-            Logger.WarnFormat("The circuit breaker for {0} will now be triggered", name);
+            Logger.WarnFormat("The circuit breaker for {0} will now be triggered with exception {1}", name, lastException);
             triggerAction(lastException);
         }
 


### PR DESCRIPTION
This implementation simplifies the implementation of the circuit breaker by no longer incrementing the failure count. The circuit breaker doesn't really care about the number of failures. It cares about tracking the potential state transitions between `Armed`, `Disarmed` and `Triggered`.

By focusing the implementation on these state transitions, the complex interaction between the `failureCount` and the `triggered` flag can be removed and replaced by a state that has meaningful names.