### PR TITLE
CircuitBreaker transition into next states only when previous state aligns with what has been read

### DIFF
--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -193,8 +193,13 @@
 
         void UpdateProcessingCapacity(int maxConcurrency)
         {
-            processor.UpdateConcurrency(maxConcurrency);
-            processor.UpdatePrefetchCount(CalculatePrefetchCount(maxConcurrency));
+            // Updating the concurrency level and prefetch count is thread safe by design
+            // We are locking here because the circuit breaker might call this method concurrently
+            lock (processor)
+            {
+                processor.UpdateConcurrency(maxConcurrency);
+                processor.UpdatePrefetchCount(CalculatePrefetchCount(maxConcurrency));
+            }
         }
 
         public async Task StopReceive(CancellationToken cancellationToken = default)


### PR DESCRIPTION
This should make sure the following outcomes happen

Thread 1 calls `Failure()`:
- Reads `previousState` as `Disarmed`.
- Attempts to change state from `Disarmed` to `Armed` using `Interlocked.CompareExchange`.
- If successful, it proceeds to invoke `armedAction()` and starts the timer.

Thread 2 calls `Success()`:
- Reads `previousState` as `Armed` (if Thread 1 has already changed it).
- Attempts to change state from `Armed` to `Disarmed` using `Interlocked.CompareExchange`.
- If successful, it proceeds to invoke `disarmedAction()` and stops the timer.

Possible Outcomes:
- If Thread 1's state change occurs before Thread 2 reads the state:
  - Thread 2 sees `previousState` as `Armed` and successfully disarms the circuit breaker.
- If Thread 2 reads the state before Thread 1 changes it:
  - Thread 2 sees `previousState` as `Disarmed` and returns early without doing anything.
- Regardless of the timing, actions are only performed when the state transitions are successful, preventing race conditions.


Additionally, this PR synchronizes access to updating the processor processing capacity because armed and disarmed actions can potentially be executed concurrently. Setting concurrency and prefetch count is thread safe in the SDK, but we want to make sure the processor state updates are done consistently. 