### PR TITLE
Allow overriding native MessageId, ContentType and CorrelationID

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -127,7 +127,7 @@ namespace NServiceBus.Transport.AzureServiceBus
                 var messagesToSend = new Queue<ServiceBusMessage>(operations.Count);
                 foreach (var operation in operations)
                 {
-                    var message = operation.Message.ToAzureServiceBusMessage(operation.Properties, azureServiceBusTransportTransaction?.IncomingQueuePartitionKey);
+                    var message = operation.ToAzureServiceBusMessage(azureServiceBusTransportTransaction?.IncomingQueuePartitionKey);
                     operation.ApplyCustomizationToOutgoingNativeMessage(message, transportTransaction, Log);
                     messagesToSend.Enqueue(message);
                 }
@@ -262,7 +262,7 @@ namespace NServiceBus.Transport.AzureServiceBus
 
                 foreach (var operation in operations)
                 {
-                    var message = operation.Message.ToAzureServiceBusMessage(operation.Properties, azureServiceBusTransportTransaction?.IncomingQueuePartitionKey);
+                    var message = operation.ToAzureServiceBusMessage(azureServiceBusTransportTransaction?.IncomingQueuePartitionKey);
                     operation.ApplyCustomizationToOutgoingNativeMessage(message, transportTransaction, Log);
                     dispatchTasks.Add(DispatchForDestination(destination, azureServiceBusTransportTransaction?.ServiceBusClient, noTransaction, message, cancellationToken));
                 }

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using Azure.Messaging.ServiceBus;
-    using Configuration;
 
     static class OutgoingMessageExtensions
     {


### PR DESCRIPTION
Alternatives:

1. Have a generic extension point `Action<TransportOperation, ServiceBusMessage>` that any customizations on the native message type and use this from the ******** connector.
2. Add extensions methods to transport operations to have type safe APIs to set these values explicitly.