### PR TITLE
Ability to not generate legacy `NServiceBus.Transport.Encoding` header

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -6,6 +6,11 @@ namespace NServiceBus
     {
         public AzureServiceBusTransport(string connectionString) { }
         public AzureServiceBusTransport(string fullyQualifiedNamespace, Azure.Core.TokenCredential tokenCredential) { }
+        [System.Obsolete("Next versions of the transport will by default no longer send the transport encod" +
+            "ing header for wire compatibility, requiring an opt-in for the header to be sent" +
+            ". Will be treated as an error from version 5.0.0. Will be removed in version 6.0" +
+            ".0.", false)]
+        public bool DoNotSendTransportEncodingHeader { get; set; }
         public bool EnablePartitioning { get; set; }
         public int EntityMaximumSize { get; set; }
         public System.TimeSpan? MaxAutoLockRenewalDuration { get; set; }
@@ -32,6 +37,11 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> ConnectionString(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string connectionString) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> CustomRetryPolicy(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, Azure.Messaging.ServiceBus.ServiceBusRetryOptions retryPolicy) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> CustomTokenCredential(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, string fullyQualifiedNamespace, Azure.Core.TokenCredential tokenCredential) { }
+        [System.Obsolete("Next versions of the transport will by default no longer send the transport encod" +
+            "ing header for wire compatibility, requiring an opt-in for the header to be sent" +
+            ". Will be treated as an error from version 5.0.0. Will be removed in version 6.0" +
+            ".0.", false)]
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> DoNotSendTransportEncodingHeader(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> EnablePartitioning(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> EntityMaximumSize(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int maximumSizeInGB) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> MaxAutoLockRenewalDuration(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.TimeSpan maximumAutoLockRenewalDuration) { }

--- a/src/Tests/Sending/OutgoingMessageExtensionsFixture.cs
+++ b/src/Tests/Sending/OutgoingMessageExtensionsFixture.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
+{
+    using System;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OutgoingMessageExtensionsTests
+    {
+        const string TransportEncoding = "NServiceBus.Transport.Encoding";
+        const string Dummy = "DUMMY";
+
+        [Test]
+        public void Should_not_contain_legacy_header_when_disabled()
+        {
+            // Arrange
+            TransportOperation transportOperation = CreateTransportOperation();
+            var transportOperations = new TransportOperations(transportOperation);
+            var outgoingMessage = transportOperations.UnicastTransportOperations[0];
+
+            // Act
+            var serviceBusMessage = outgoingMessage.ToAzureServiceBusMessage(incomingQueuePartitionKey: Dummy, doNotSendTransportEncodingHeader: true);
+
+            Assert.That(serviceBusMessage.ApplicationProperties.Keys, Has.No.Member(TransportEncoding));
+        }
+
+
+        [Test]
+        public void Should_contain_legacy_header_by_default()
+        {
+            // Arrange
+            TransportOperation transportOperation = CreateTransportOperation();
+            var transportOperations = new TransportOperations(transportOperation);
+            var outgoingMessage = transportOperations.UnicastTransportOperations[0];
+
+            // Act
+            var serviceBusMessage = outgoingMessage.ToAzureServiceBusMessage(incomingQueuePartitionKey: Dummy);
+
+            Assert.That(serviceBusMessage.ApplicationProperties.Keys, Has.Member(TransportEncoding));
+        }
+
+        static TransportOperation CreateTransportOperation()
+        {
+            var messageId = Guid.NewGuid().ToString();
+            var message = new OutgoingMessage(messageId, [], ReadOnlyMemory<byte>.Empty);
+            var transportOperation = new TransportOperation(
+                message,
+                addressTag: new UnicastAddressTag(Dummy),
+                properties: null,
+                DispatchConsistency.Default
+            );
+            return transportOperation;
+        }
+    }
+}

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -329,6 +329,14 @@
         }
         IWebProxy webProxy;
 
+        /// <summary>
+        /// When set will not add `NServiceBus.Transport.Encoding` header for wire compatibility with NServiceBus.AzureServiceBus. The default value is <c>false</c>.
+        /// </summary>
+        [ObsoleteEx(Message = "Next versions of the transport will by default no longer send the transport encoding header for wire compatibility, requiring an opt-in for the header to be sent.",
+            TreatAsErrorFromVersion = "5",
+            RemoveInVersion = "6")]
+        public bool DoNotSendTransportEncodingHeader { get; set; }
+
         internal string ConnectionString { get; set; }
 
         internal string FullyQualifiedNamespace { get; set; }

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -26,7 +26,12 @@
 
             messageSenderRegistry = new MessageSenderRegistry(defaultClient);
 
-            Dispatcher = new MessageDispatcher(messageSenderRegistry, transportSettings.Topology.TopicToPublishTo, transportSettings.OutgoingNativeMessageCustomization);
+            Dispatcher = new MessageDispatcher(
+                messageSenderRegistry,
+                transportSettings.Topology.TopicToPublishTo,
+                transportSettings.OutgoingNativeMessageCustomization,
+                transportSettings.DoNotSendTransportEncodingHeader
+                );
             Receivers = receiveSettingsAndClientPairs.ToDictionary(static settingsAndClient =>
             {
                 var (receiveSettings, _) = settingsAndClient;

--- a/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
@@ -229,7 +229,8 @@
         /// Overrides the default maximum duration within which the lock will be renewed automatically. This
         /// value should be greater than the longest message lock duration.
         /// </summary>
-        /// <value>The maximum duration during which message locks are automatically renewed. The default value is 5 minutes.</value>
+        /// <param name="transportExtensions"></param>
+        /// <param name="maximumAutoLockRenewalDuration">The maximum duration during which message locks are automatically renewed. The default value is 5 minutes.</param>
         /// <remarks>The message renew can continue for sometime in the background
         /// after completion of message and result in a few false MessageLockLostExceptions temporarily.</remarks>
         [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
@@ -239,6 +240,19 @@
         {
             Guard.AgainstNegative(nameof(maximumAutoLockRenewalDuration), maximumAutoLockRenewalDuration);
             transportExtensions.Transport.MaxAutoLockRenewalDuration = maximumAutoLockRenewalDuration;
+            return transportExtensions;
+        }
+
+        /// <summary>
+        /// When set will not add `NServiceBus.Transport.Encoding` header for wire compatibility with NServiceBus.AzureServiceBus. The default value is <c>false</c>.
+        /// </summary>
+        /// <param name="transportExtensions"></param>
+        [ObsoleteEx(Message = "Next versions of the transport will by default no longer send the transport encoding header for wire compatibility, requiring an opt-in for the header to be sent.",
+            TreatAsErrorFromVersion = "5",
+            RemoveInVersion = "6")]
+        public static TransportExtensions<AzureServiceBusTransport> DoNotSendTransportEncodingHeader(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+        {
+            transportExtensions.Transport.DoNotSendTransportEncodingHeader = true;
             return transportExtensions;
         }
     }


### PR DESCRIPTION
Add operation extension to not generate legacy `NServiceBus.Transport.Encoding` header in native custom properties / ApplicationProperties