### PR TITLE
Support reading from dead-letter queues with transport seam

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -86,3 +86,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         public static System.Transactions.TransactionScope ToTransactionScope(this NServiceBus.Transport.AzureServiceBus.AzureServiceBusTransportTransaction azureServiceBusTransaction) { }
     }
 }
+public static class QueueAddressQualifier
+{
+    public const string DeadLetterQueue = "$DeadLetterQueue";
+}

--- a/src/Transport/Receiving/QueueAddressQualifier.cs
+++ b/src/Transport/Receiving/QueueAddressQualifier.cs
@@ -1,0 +1,10 @@
+/// <summary>
+/// Queue address qualifiers
+/// </summary>
+public static class QueueAddressQualifier
+{
+    /// <summary>
+    /// Qualifier that identifies the Azure Service Bus native dead-letter subqueue 
+    /// </summary>
+    public const string DeadLetterQueue = "$DeadLetterQueue";
+}

--- a/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
+++ b/src/TransportTests/ConfigureAzureServiceBusTransportInfrastructure.cs
@@ -9,14 +9,15 @@ using NServiceBus.TransportTests;
 
 public class ConfigureAzureServiceBusTransportInfrastructure : IConfigureTransportInfrastructure
 {
+    public static readonly string ConnectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
+
     public TransportDefinition CreateTransportDefinition()
     {
-        var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString");
-        if (string.IsNullOrEmpty(connectionString))
+        if (string.IsNullOrEmpty(ConnectionString))
         {
             throw new InvalidOperationException("envvar AzureServiceBus_ConnectionString not set");
         }
-        var transport = new AzureServiceBusTransport(connectionString)
+        var transport = new AzureServiceBusTransport(ConnectionString)
         {
             SubscriptionNamingConvention = name =>
             {

--- a/src/TransportTests/When_using_dlq_qualifier.cs
+++ b/src/TransportTests/When_using_dlq_qualifier.cs
@@ -1,0 +1,254 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.TransportTests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using NUnit.Framework;
+using Routing;
+
+[TestFixture]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+[Parallelizable(ParallelScope.All)]
+[CancelAfter(15000)]
+public class When_using_dlq_qualifier
+{
+    const string TestIdHeaderKey = "TestId";
+    string inputQueueName;
+    readonly string TestId = Guid.NewGuid().ToString();
+    CancellationToken StopToken => TestContext.CurrentContext.CancellationToken;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var test = TestContext.CurrentContext.Test;
+        inputQueueName = $"{test.DisplayName}.{test.Name}";
+        inputQueueName = string.Join("_", inputQueueName.Split(['(', ')']));
+    }
+
+    [Test]
+    public async Task Should_receive_from_dlq()
+    {
+        // Setup
+        await SendViaTransportSeam(StopToken);
+        await ReceiveAndDeadLetterViaSdk(StopToken);
+        // Act
+        await BlockUntilReceivedViaTransportSeam(StopToken);
+        // Assert
+        Assert.Pass("Received message");
+    }
+
+    [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+    [TestCase(TransportTransactionMode.ReceiveOnly)]
+    [TestCase(TransportTransactionMode.None)]
+    public async Task Should_work_with_transactionmode(TransportTransactionMode mode)
+    {
+        // Arrange
+        await SendViaTransportSeam(StopToken);
+        await ReceiveAndDeadLetterViaSdk(StopToken);
+        // Act
+        await SeamReceiveFromDlqAndSendTestMessage(mode, StopToken);
+        var received = await NativeBlockUntilReceiveMessage(StopToken);
+        // Assert
+        switch (mode)
+        {
+            case TransportTransactionMode.SendsAtomicWithReceive:
+            case TransportTransactionMode.TransactionScope:
+                if (received)
+                {
+                    Assert.Fail($"Incorrectly received test message");
+                }
+
+                break;
+            case TransportTransactionMode.None:
+            case TransportTransactionMode.ReceiveOnly:
+                if (!received)
+                {
+                    Assert.Fail("Should have received test message");
+                }
+
+                break;
+            default:
+                break;
+        }
+    }
+
+    async Task<bool> NativeBlockUntilReceiveMessage(CancellationToken cancellationToken)
+    {
+        string fullyQualifiedNamespace = ConfigureAzureServiceBusTransportInfrastructure.ConnectionString;
+        await using ServiceBusClient client = new(fullyQualifiedNamespace);
+        var receiver = client.CreateReceiver(inputQueueName, new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
+        try
+        {
+            await foreach (var receivedMessage in receiver.ReceiveMessagesAsync(cancellationToken: cancellationToken))
+            {
+                var testId = receivedMessage.ApplicationProperties[TestIdHeaderKey];
+                Console.WriteLine($"Receive test {testId} but waiting for {TestId}");
+                if (TestId == (string)testId)
+                {
+                    return true;
+                }
+            }
+
+            throw new InvalidOperationException("Unexpected as ReceivedMessagesAsync should throw OperationCanceledException");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return false;
+        }
+    }
+
+    async Task SeamReceiveFromDlqAndSendTestMessage(TransportTransactionMode mode, CancellationToken cancellationToken)
+    {
+        var c = new ConfigureAzureServiceBusTransportInfrastructure();
+        var transportDefinition = (AzureServiceBusTransport)c.CreateTransportDefinition();
+        transportDefinition.TransportTransactionMode = mode;
+
+        var hostSettings = new HostSettings(
+            inputQueueName,
+            string.Empty,
+            new StartupDiagnosticEntries(),
+            (message, ex, token) => { },
+            false
+        );
+
+        var deadLetterQueue = new QueueAddress(inputQueueName, qualifier: QueueAddressQualifier.DeadLetterQueue);
+
+        const string receiverKey = "1";
+
+        var transportInfrastructure = await transportDefinition.Initialize(
+            hostSettings,
+            [new ReceiveSettings(receiverKey, deadLetterQueue, true, false, hostSettings.Name + ".error")],
+            [],
+            cancellationToken
+        );
+
+
+        var waitForDlqMessageToBeReceived = new TaskCompletionSource();
+        var dlqReceiver = transportInfrastructure.Receivers[receiverKey];
+        await dlqReceiver.Initialize(
+            new PushRuntimeSettings(), async (context, _) =>
+            {
+                var testId = context.Headers[TestIdHeaderKey];
+                if (testId == TestId)
+                {
+                    Console.WriteLine("Send new message");
+                    var message = new OutgoingMessage(TestId, new Dictionary<string, string> { [TestIdHeaderKey] = TestId }, null);
+                    var operation = new TransportOperation(message, new UnicastAddressTag(inputQueueName));
+                    var operations = new TransportOperations(operation);
+                    await transportInfrastructure.Dispatcher.Dispatch(operations, context.TransportTransaction, cancellationToken);
+                    Console.WriteLine("Signal received");
+                    waitForDlqMessageToBeReceived.TrySetResult();
+                    throw new Exception("Force the TX to rollback");
+                }
+            },
+            (context, token) => Task.FromResult(ErrorHandleResult.Handled), cancellationToken);
+
+        await dlqReceiver.StartReceive(cancellationToken);
+
+        cancellationToken.Register(() => waitForDlqMessageToBeReceived.TrySetCanceled(cancellationToken));
+        Console.WriteLine("Waiting for receive.....");
+        await waitForDlqMessageToBeReceived.Task;
+        foreach (var r in transportInfrastructure.Receivers.Values)
+        {
+            await r.StopReceive(cancellationToken);
+        }
+
+        await transportInfrastructure.Shutdown(cancellationToken);
+        Console.WriteLine("Shutdown completed!");
+    }
+
+    async Task SendViaTransportSeam(CancellationToken cancellationToken)
+    {
+        var c = new ConfigureAzureServiceBusTransportInfrastructure();
+        var transportDefinition = (AzureServiceBusTransport)c.CreateTransportDefinition();
+
+        var hostSettings = new HostSettings(
+            inputQueueName,
+            string.Empty,
+            new StartupDiagnosticEntries(),
+            (_, _, _) => { },
+            true
+        );
+
+        var transportInfrastructure = await transportDefinition.Initialize(hostSettings,
+            [new ReceiveSettings("1", new QueueAddress(inputQueueName), true, true, hostSettings.Name + ".error")], // Required for the queue to be created
+            [],
+            cancellationToken
+        );
+
+        var message = new OutgoingMessage(TestId, new Dictionary<string, string> { [TestIdHeaderKey] = TestId }, null);
+        var operation = new TransportOperation(message, new UnicastAddressTag(inputQueueName));
+        var operations = new TransportOperations(operation);
+        await transportInfrastructure.Dispatcher.Dispatch(operations, new TransportTransaction(), cancellationToken);
+        await transportInfrastructure.Shutdown(cancellationToken);
+    }
+
+    async Task ReceiveAndDeadLetterViaSdk(CancellationToken cancellationToken)
+    {
+        string fullyQualifiedNamespace = ConfigureAzureServiceBusTransportInfrastructure.ConnectionString;
+        await using ServiceBusClient client = new(fullyQualifiedNamespace);
+
+        var receiver = client.CreateReceiver(inputQueueName);
+        await foreach (var receivedMessage in receiver.ReceiveMessagesAsync(cancellationToken: cancellationToken))
+        {
+            var testId = receivedMessage.ApplicationProperties[TestIdHeaderKey];
+            if (TestId == (string)testId)
+            {
+                await receiver.DeadLetterMessageAsync(receivedMessage, "unittest", "DLQ message to test receiving from DLQ", cancellationToken);
+                return;
+            }
+        }
+    }
+
+    async Task BlockUntilReceivedViaTransportSeam(CancellationToken cancellationToken)
+    {
+        var c = new ConfigureAzureServiceBusTransportInfrastructure();
+        var transportDefinition = (AzureServiceBusTransport)c.CreateTransportDefinition();
+
+        var hostSettings = new HostSettings(
+            inputQueueName,
+            string.Empty,
+            new StartupDiagnosticEntries(),
+            (message, ex, token) => { },
+            true
+        );
+
+        var deadLetterQueue = new QueueAddress(inputQueueName, qualifier: QueueAddressQualifier.DeadLetterQueue);
+
+        const string receiverKey = "1";
+
+        var transportInfrastructure = await transportDefinition.Initialize(
+            hostSettings,
+            [new ReceiveSettings(receiverKey, deadLetterQueue, true, false, hostSettings.Name + ".error")],
+            [], cancellationToken);
+
+        var waitForDlqMessageToBeReceived = new TaskCompletionSource();
+        var dlqReceiver = transportInfrastructure.Receivers[receiverKey];
+        await dlqReceiver.Initialize(
+            new PushRuntimeSettings(),
+            (context, _) =>
+            {
+                var testId = context.Headers[TestIdHeaderKey];
+                if (testId == TestId)
+                {
+                    waitForDlqMessageToBeReceived.SetResult();
+                }
+
+                return Task.CompletedTask;
+            },
+            (context, token) => Task.FromResult(ErrorHandleResult.Handled), cancellationToken);
+
+        await dlqReceiver.StartReceive(cancellationToken);
+
+        cancellationToken.Register(() => waitForDlqMessageToBeReceived.SetCanceled(cancellationToken));
+        await waitForDlqMessageToBeReceived.Task;
+        foreach (var r in transportInfrastructure.Receivers.Values)
+        {
+            await r.StopReceive(cancellationToken).ConfigureAwait(false);
+        }
+
+        await transportInfrastructure.Shutdown(cancellationToken);
+    }
+}


### PR DESCRIPTION
Support reading from dead-letter queues with transport seam:

Create `ReceiveSettings` with property key `Azure.Messaging.ServiceBus.SubQueue` and the value to match `DeadLetter`:

```c#
var queueProperties = new Dictionary<string, string>(1);
queueProperties[typeof(SubQueue).FullName] = SubQueue.DeadLetter.ToString();

var receiveSettings = new ReceiveSettings(
    id: inputQueue,
    receiveAddress: new QueueAddress(inputQueue, properties: queueProperties),
    usePublishSubscribe: false,
    purgeOnStartup: false,
    errorQueue: errorQueue
```
