### PR TITLE
Allow customizing outgoing native ServiceBusMessage

### DIFF
--- a/src/AcceptanceTests/When_customizing_outgoing_messages.cs
+++ b/src/AcceptanceTests/When_customizing_outgoing_messages.cs
@@ -34,9 +34,8 @@ namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
             public Receiver() =>
                 EndpointSetup<DefaultServer>(endpointConfiguration =>
                 {
-                    var t = (AzureServiceBusTransport)endpointConfiguration.ConfigureTransport();
-                    t.OutgoingNativeMessageCustomization =
-                        (_, message) => message.Subject = TestSubject;
+                    var transport = endpointConfiguration.ConfigureTransport<AzureServiceBusTransport>();
+                    transport.OutgoingNativeMessageCustomization = (_, message) => message.Subject = TestSubject;
                 });
 
             class MyEventHandler(Context testContext) : IHandleMessages<Message>

--- a/src/AcceptanceTests/When_customizing_outgoing_messages.cs
+++ b/src/AcceptanceTests/When_customizing_outgoing_messages.cs
@@ -1,0 +1,70 @@
+namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Azure.Messaging.ServiceBus;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    class When_customizing_outgoing_messages : NServiceBusAcceptanceTest
+    {
+        const string TestSubject = "0192c3ad-8ab2-77a0-8a92-2be53f062e06";
+
+        [Test]
+        public async Task Should_receive_custom_set_value()
+        {
+            var scenario = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(b => b.When((bus, c) => bus.SendLocal(new Message())))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.That(scenario.ReceivedMessage.Subject, Is.EqualTo(TestSubject));
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(endpointConfiguration =>
+                {
+                    var t = (AzureServiceBusTransport)endpointConfiguration.ConfigureTransport();
+                    t.OutgoingNativeMessageCustomization =
+                        (operation, message) =>
+                        {
+                            message.Subject = TestSubject;
+                        };
+                });
+            }
+
+            class MyEventHandler : IHandleMessages<Message>
+            {
+                Context testContext;
+
+                public MyEventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessage = context.Extensions.Get<ServiceBusReceivedMessage>();
+                    testContext.MessageReceived = true;
+
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class Message : IMessage
+        {
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+
+            public ServiceBusReceivedMessage ReceivedMessage { get; set; }
+        }
+    }
+}

--- a/src/AcceptanceTests/When_customizing_outgoing_messages.cs
+++ b/src/AcceptanceTests/When_customizing_outgoing_messages.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
         {
             var scenario = await Scenario.Define<Context>()
                 .WithEndpoint<Receiver>(b => b.When((bus, c) => bus.SendLocal(new Message())))
-                .Done(c => c.MessageReceived)
+                .Done(c => c.ReceivedMessage != null)
                 .Run();
 
             Assert.That(scenario.ReceivedMessage.Subject, Is.EqualTo(TestSubject));
@@ -24,8 +24,6 @@ namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
 
         class Context : ScenarioContext
         {
-            public bool MessageReceived { get; set; }
-
             public ServiceBusReceivedMessage ReceivedMessage { get; set; }
         }
 
@@ -43,8 +41,6 @@ namespace NServiceBus.Transport.RabbitMQ.AcceptanceTests
                 public Task Handle(Message message, IMessageHandlerContext context)
                 {
                     testContext.ReceivedMessage = context.Extensions.Get<ServiceBusReceivedMessage>();
-                    testContext.MessageReceived = true;
-
                     return Task.CompletedTask;
                 }
             }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -9,6 +9,7 @@ namespace NServiceBus
         public bool EnablePartitioning { get; set; }
         public int EntityMaximumSize { get; set; }
         public System.TimeSpan? MaxAutoLockRenewalDuration { get; set; }
+        public System.Action<NServiceBus.Transport.IOutgoingTransportOperation, Azure.Messaging.ServiceBus.ServiceBusMessage> OutgoingNativeMessageCustomization { get; set; }
         public int? PrefetchCount { get; set; }
         public int PrefetchMultiplier { get; set; }
         public Azure.Messaging.ServiceBus.ServiceBusRetryOptions RetryPolicyOptions { get; set; }

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -333,5 +333,20 @@
 
         internal string FullyQualifiedNamespace { get; set; }
         internal TokenCredential TokenCredential { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action that allows customization of the native <see cref="ServiceBusMessage"/> 
+        /// just before it is dispatched to the Azure Service Bus SDK client. 
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This customization is applied after any configured transport customizations, meaning that 
+        /// any changes made here may override or conflict with previous transport-level adjustments. 
+        /// Exercise caution, as modifying the message at this stage can lead to unintended behavior 
+        /// downstream if the message structure or properties are altered in ways that do not align 
+        /// with expectations elsewhere in the system.
+        /// </para>
+        /// </remarks>
+        public OutgoingNativeMessageCustomizationAction OutgoingNativeMessageCustomization { get; set; }
     }
 }

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -26,7 +26,7 @@
 
             messageSenderRegistry = new MessageSenderRegistry(defaultClient);
 
-            Dispatcher = new MessageDispatcher(messageSenderRegistry, transportSettings.Topology.TopicToPublishTo);
+            Dispatcher = new MessageDispatcher(messageSenderRegistry, transportSettings.Topology.TopicToPublishTo, transportSettings.OutgoingNativeMessageCustomization);
             Receivers = receiveSettingsAndClientPairs.ToDictionary(static settingsAndClient =>
             {
                 var (receiveSettings, _) = settingsAndClient;

--- a/src/Transport/OutgoingNativeMessageCustomizationAction.cs
+++ b/src/Transport/OutgoingNativeMessageCustomizationAction.cs
@@ -1,0 +1,1 @@
+global using OutgoingNativeMessageCustomizationAction = System.Action<NServiceBus.Transport.IOutgoingTransportOperation, Azure.Messaging.ServiceBus.ServiceBusMessage>;

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -30,12 +30,7 @@ namespace NServiceBus.Transport.AzureServiceBus
         {
             this.messageSenderRegistry = messageSenderRegistry;
             this.topicName = topicName;
-            this.customizerCallback = customizerCallback ?? NoopNativeMessageCustomizerCallback;
-        }
-
-        static void NoopNativeMessageCustomizerCallback(IOutgoingTransportOperation message, ServiceBusMessage nativeMessage)
-        {
-            // Noop callback to not require a null check
+            this.customizerCallback = customizerCallback ?? (static (_, _) => { }); // Noop callback to not require a null check
         }
 
         public async Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)

--- a/src/Transport/Sending/NativeMessageCustomizationBehavior.cs
+++ b/src/Transport/Sending/NativeMessageCustomizationBehavior.cs
@@ -39,7 +39,7 @@
             var customizationId = Guid.NewGuid().ToString();
             customizer.Customizations.TryAdd(customizationId, customization);
 
-            // Store they key to the customization in the dispatch properties that are passed to the transport
+            // Store the key to the customization in the dispatch properties that are passed to the transport
             context.Extensions.Get<DispatchProperties>()[CustomizationKey] = customizationId;
 
             return next();


### PR DESCRIPTION
Replaces:

- https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1071

Added the ability to customize then native message type just before it is dispatched to Azure Service Bus and gets access to [IOutgoingTransportOperation](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Transports/IOutgoingTransportOperation.cs).

```c#
var transport = new AzureServiceBusTransport(connectionstring);
//...
transport.OutgoingNativeMessageCustomization = (outgoingoperation, servicebusmessage) => { servicebusmessage.ContentType = "text/xml" };
```

or

```c#
public Task MyCustomizer(IOutgoingTransportOperation message, ServiceBusMessage nativeMessage)
{
}

var transport = new AzureServiceBusTransport(connectionstring);
//...
transport.OutgoingNativeMessageCustomization = MyCustomizer;
```
