### PR TITLE
Stop pumps on shutdown

### DIFF
--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -85,6 +85,9 @@
 
         public override async Task Shutdown(CancellationToken cancellationToken = default)
         {
+            await Task.WhenAll(Receivers.Values.Select(r => r.StopReceive(cancellationToken)))
+                .ConfigureAwait(false);
+
             if (messageSenderRegistry != null)
             {
                 await messageSenderRegistry.Close(cancellationToken).ConfigureAwait(false);

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -110,22 +110,17 @@
                 queue.Append($"-{address.Discriminator}");
             }
 
-            if (address.Qualifier != null)
+            if (address.Qualifier != null && !QueueAddressQualifier.DeadLetterQueue.Equals(address.Qualifier, StringComparison.OrdinalIgnoreCase))
             {
-                if (!QueueAddressQualifier.DeadLetterQueue.Equals(address.Qualifier, StringComparison.OrdinalIgnoreCase))
-                {
-                    queue.Append($".{address.Qualifier}");
-                }
+                queue.Append($".{address.Qualifier}");
             }
 
             return queue.ToString();
         }
 
-        static SubQueue ToSubQueue(QueueAddress address)
-        {
-            return QueueAddressQualifier.DeadLetterQueue.Equals(address.Qualifier, StringComparison.OrdinalIgnoreCase)
+        static SubQueue ToSubQueue(QueueAddress address) =>
+            QueueAddressQualifier.DeadLetterQueue.Equals(address.Qualifier, StringComparison.OrdinalIgnoreCase)
                 ? SubQueue.DeadLetter
                 : SubQueue.None;
-        }
     }
 }

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Transport.AzureServiceBus
+﻿#nullable enable
+
+namespace NServiceBus.Transport.AzureServiceBus
 {
     using System;
     using System.Linq;
@@ -88,10 +90,7 @@
             await Task.WhenAll(Receivers.Values.Select(r => r.StopReceive(cancellationToken)))
                 .ConfigureAwait(false);
 
-            if (messageSenderRegistry != null)
-            {
-                await messageSenderRegistry.Close(cancellationToken).ConfigureAwait(false);
-            }
+            await messageSenderRegistry.Close(cancellationToken).ConfigureAwait(false);
 
             foreach (var (_, serviceBusClient) in receiveSettingsAndClientPairs)
             {

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -205,6 +205,12 @@
 
         public async Task StopReceive(CancellationToken cancellationToken = default)
         {
+            if (messageProcessingCancellationTokenSource is null)
+            {
+                // Receiver hasn't been started or is already stopped
+                return;
+            }
+
             // Wiring up the stop token to trigger the cancellation token that is being
             // used inside the message handling pipeline
             await using var _ = cancellationToken


### PR DESCRIPTION
This aligns the transport to stop the pumps on transport shutdown and at the same time makes sure the pumps stop method can be called multiple times. 

This is part of addressing some low-hanging fruit to align all transports for the transport seam usage scenarios to make sure pumps are stopped when the transport shuts down. 

I have tried to write a transport test for it to enforce it eventually for all transport but couldn't find a way to do that without introducing flags on the transport interface and using fancy techniques like default members which seams overkill