### PR TITLE
Not all internal resources are disposed before shutting down

### DIFF
--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -105,7 +105,6 @@ namespace NServiceBus.Transport.AzureServiceBus
 
             if (address.Qualifier != null)
             {
-
                 queue.Append($".{address.Qualifier}");
             }
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -199,6 +199,12 @@
 
         public async Task StopReceive(CancellationToken cancellationToken = default)
         {
+            if (messageProcessingCancellationTokenSource is null)
+            {
+                // Receiver hasn't been started or is already stopped
+                return;
+            }
+
             // Wiring up the stop token to trigger the cancellation token that is being
             // used inside the message handling pipeline
             await using var _ = cancellationToken


### PR DESCRIPTION
### Describe the bug

#### Description
When a transport is shutting down, it should be able to dispose all internal resources that it created.

#### Expected behavior
All pumps are stopped by the transport.

#### Actual behavior
The receiving pumps need to be stopped manually after shutdown.

#### Versions
All supported versions


### Steps to reproduce

N/A

### Additional Information

#### Workarounds

#### Possible solutions

#### Additional information