### PR TITLE
Update the command line tool to not use .Net 7

### DIFF
--- a/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
@@ -7,6 +7,7 @@
     <PackAsTool>True</PackAsTool>
     <Description>.NET Core global tool to manage Azure Service Bus entities for NServiceBus endpoints</Description>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ToolCommandName>asb-transport</ToolCommandName>
     <PackAsTool>True</PackAsTool>

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -348,7 +348,7 @@
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.WorkingDirectory = TestContext.CurrentContext.TestDirectory;
             process.StartInfo.FileName = "dotnet";
-            process.StartInfo.Arguments = "NServiceBus.Transport.AzureServiceBus.CommandLine.dll " + command;
+            process.StartInfo.Arguments = $"--fx-version {Environment.Version} NServiceBus.Transport.AzureServiceBus.CommandLine.dll " + command;
 
             process.Start();
             var outputTask = process.StandardOutput.ReadToEndAsync();


### PR DESCRIPTION
The absence of .Net 7 on the Github runner is breaking the build pipeline. 
.Net 7 was added on https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/759
This change makes the command line tool single target, but sets the roll forward behavior to `Major` and adds the target framework to the command that the tests execute.