### PR TITLE
Adding support to new topology to the command line tool

### DIFF
--- a/src/CommandLine/MigrationTopologyEndpoint.cs
+++ b/src/CommandLine/MigrationTopologyEndpoint.cs
@@ -6,7 +6,7 @@
     using Azure.Messaging.ServiceBus.Administration;
     using McMaster.Extensions.CommandLineUtils;
 
-    static class Endpoint
+    static class MigrationTopologyEndpoint
     {
         public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption topicName, CommandOption topicToPublishTo, CommandOption topicToSubscribeOn, CommandOption subscriptionName, CommandOption<int> size, CommandOption partitioning)
         {
@@ -23,7 +23,7 @@
             {
                 try
                 {
-                    await Topic.Create(client, topicName, size, partitioning);
+                    await Topic.Create(client, topicName.Value(), size, partitioning);
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
                 {
@@ -48,7 +48,7 @@
             {
                 try
                 {
-                    await Topic.Create(client, topicToPublishTo, size, partitioning);
+                    await Topic.Create(client, topicToPublishTo.Value(), size, partitioning);
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
                 {
@@ -57,7 +57,7 @@
 
                 try
                 {
-                    await Topic.Create(client, topicToSubscribeOn, size, partitioning);
+                    await Topic.Create(client, topicToSubscribeOn.Value(), size, partitioning);
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
                 {

--- a/src/CommandLine/Subscription.cs
+++ b/src/CommandLine/Subscription.cs
@@ -25,6 +25,23 @@
             return client.CreateSubscriptionAsync(options, new CreateRuleOptions("$default", new FalseRuleFilter()));
         }
 
+        public static Task Create(ServiceBusAdministrationClient client, CommandArgument endpointName, CommandArgument topicName, CommandOption subscriptionName)
+        {
+            var subscriptionNameToUse = subscriptionName.HasValue() ? subscriptionName.Value() : endpointName.Value;
+
+            var options = new CreateSubscriptionOptions(topicName.Value, subscriptionNameToUse)
+            {
+                LockDuration = TimeSpan.FromMinutes(5),
+                ForwardTo = endpointName.Value,
+                EnableDeadLetteringOnFilterEvaluationExceptions = false,
+                MaxDeliveryCount = int.MaxValue,
+                EnableBatchedOperations = true,
+                UserMetadata = endpointName.Value
+            };
+
+            return client.CreateSubscriptionAsync(options, new CreateRuleOptions("$default", new FalseRuleFilter()));
+        }
+
         public static Task CreateForwarding(ServiceBusAdministrationClient client, CommandOption topicToPublishTo, CommandOption topicToSubscribeTo, string subscriptionName)
         {
             var options = new CreateSubscriptionOptions(topicToPublishTo.Value(), subscriptionName)
@@ -38,6 +55,13 @@
             };
 
             return client.CreateSubscriptionAsync(options, new CreateRuleOptions("$default", new TrueRuleFilter()));
+        }
+
+        public static Task Delete(ServiceBusAdministrationClient client, CommandArgument endpointName,
+            CommandArgument topicName, CommandOption subscriptionName)
+        {
+            var subscriptionNameToUse = subscriptionName.HasValue() ? subscriptionName.Value() : endpointName.Value;
+            return client.DeleteSubscriptionAsync(topicName.Value, subscriptionNameToUse);
         }
     }
 }

--- a/src/CommandLine/Topic.cs
+++ b/src/CommandLine/Topic.cs
@@ -6,10 +6,8 @@
 
     static class Topic
     {
-        public static Task Create(ServiceBusAdministrationClient client, CommandOption topicName, CommandOption<int> size, CommandOption partitioning)
+        public static Task Create(ServiceBusAdministrationClient client, string topicNameToUse, CommandOption<int> size, CommandOption partitioning)
         {
-            var topicNameToUse = topicName.Value();
-
             var options = new CreateTopicOptions(topicNameToUse)
             {
                 EnableBatchedOperations = true,

--- a/src/CommandLine/TopicPerEventTopologyEndpoint.cs
+++ b/src/CommandLine/TopicPerEventTopologyEndpoint.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.CommandLine;
+
+using System;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using McMaster.Extensions.CommandLineUtils;
+
+static class TopicPerEventTopologyEndpoint
+{
+    public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption<int> size, CommandOption partitioning)
+    {
+        try
+        {
+            await Queue.Create(client, name, size, partitioning);
+        }
+        catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+        {
+            Console.WriteLine($"Queue '{name.Value}' already exists, skipping creation");
+        }
+    }
+
+    public static async Task Subscribe(ServiceBusAdministrationClient client, CommandArgument name, CommandArgument topicName, CommandOption subscriptionName, CommandOption<int> size, CommandOption partitioning)
+    {
+        try
+        {
+            await Topic.Create(client, topicName.Value, size, partitioning);
+        }
+        catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+        {
+            Console.WriteLine($"Topic '{topicName.Value}' already exists, skipping creation");
+        }
+
+        try
+        {
+            await Subscription.Create(client, name, topicName, subscriptionName);
+        }
+        catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+        {
+            Console.WriteLine($"Subscription '{name.Value}' already exists, skipping creation");
+        }
+    }
+
+    public static async Task Unsubscribe(ServiceBusAdministrationClient client, CommandArgument name, CommandArgument topicName, CommandOption subscriptionName)
+    {
+        try
+        {
+            await Subscription.Delete(client, name, topicName, subscriptionName);
+        }
+        catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+        {
+            Console.WriteLine($"Subscription '{name.Value}' already exists, skipping creation");
+        }
+    }
+}


### PR DESCRIPTION
Adds support to new topology to the command line tool:
 - `topology` is a new required parameter for the `endpoint` command with values either `migration` or `topic-per-event`
 - `subscribe` and `unsubscribe` use topic-per-event topology
 - `subscribe-non-migrated` and `unsubscribe-non-migrated` use the old topology

Note: it seems impossible to use single "subscribe" commands with a topology parameter because, depending on the topology, the arguments for the commands are different (not only options).