### PR TITLE
Use topology options instead of topology when writing to diagnostics file

### DIFF
--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -57,7 +57,7 @@ sealed class AzureServiceBusTransportInfrastructure : TransportInfrastructure
     void WriteStartupDiagnostics(StartupDiagnosticEntries startupDiagnostic) =>
         startupDiagnostic.Add("Azure Service Bus transport", new
         {
-            transportSettings.Topology,
+            Topology = transportSettings.Topology.Options,
             EntityMaximumSize = transportSettings.EntityMaximumSize.ToString(),
             EnablePartitioning = transportSettings.EnablePartitioning.ToString(),
             PrefetchMultiplier = transportSettings.PrefetchMultiplier.ToString(),


### PR DESCRIPTION
Because the `TopicTopology` class has obsolete properties, it is not possible to use it in the diagnostics (the serializer attempts to access them). The other benefit of using the options is the fact that the diagnostics file now includes the full information about the event mapping e.g.

```json
"Azure Service Bus transport": {
    "Topology": {
      "$type": "migration-topology-options",
      "TopicToPublishTo": "bundle-1",
      "TopicToSubscribeOn": "bundle-1",
      "EventsToMigrateMap": [
        "Shared.MyEvent"
      ],
      "SubscribedEventToRuleNameMap": {
        
      },
      "PublishedEventToTopicsMap": {
        
      },
      "SubscribedEventToTopicsMap": {
        
      },
      "QueueNameToSubscriptionNameMap": {
        
      }
    },
    "EntityMaximumSize": "5",
    "EnablePartitioning": "False",
    "PrefetchMultiplier": "10",
    "PrefetchCount": "default",
    "UseWebSockets": "False",
    "TimeToWaitBeforeTriggeringCircuitBreaker": "00:02:00",
    "CustomTokenProvider": "default",
    "CustomRetryPolicy": "default"
  },
```