### PR TITLE
Introduce subscribe overloads that allow mapping to implementation type using the default convention

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -244,7 +244,10 @@ namespace NServiceBus.Transport.AzureServiceBus
         public void PublishTo(System.Type eventType, string topicName) { }
         public void PublishTo<TEventType>(string topicName) { }
         public void SubscribeTo(System.Type eventType, string topicName) { }
+        public void SubscribeTo(System.Type eventType, System.Type eventTypeImplementation) { }
         public void SubscribeTo<TEventType>(string topicName) { }
+        public void SubscribeTo<TEventType, TEventTypeImplementation>()
+            where TEventTypeImplementation : TEventType { }
     }
     [System.Text.Json.Serialization.JsonDerivedType(typeof(NServiceBus.Transport.AzureServiceBus.MigrationTopologyOptions), "migration-topology-options")]
     [System.Text.Json.Serialization.JsonDerivedType(typeof(NServiceBus.Transport.AzureServiceBus.TopologyOptions), "topology-options")]

--- a/src/Transport/EventRouting/TopicPerEventTopology.cs
+++ b/src/Transport/EventRouting/TopicPerEventTopology.cs
@@ -37,6 +37,29 @@ public sealed class TopicPerEventTopology : TopicTopology
     }
 
     /// <summary>
+    /// Instructs the topology to use provided topic to subscribe for events of a given type applying the default convention
+    /// of subscribing to the event under a topic name that is the full name of the event type.
+    /// </summary>
+    /// <typeparam name="TEventType">Type of the event.</typeparam>
+    /// <typeparam name="TEventTypeImplementation">Type of the event implementation.</typeparam>
+    /// <exception cref="ArgumentException">The topic name is not set.</exception>
+    public void SubscribeTo<TEventType, TEventTypeImplementation>() where TEventTypeImplementation : TEventType =>
+        SubscribeTo(typeof(TEventType), typeof(TEventTypeImplementation));
+
+    /// <summary>
+    /// Instructs the topology to use provided topic to subscribe for events of a given type applying the default convention
+    /// of subscribing to the event under a topic name that is the full name of the event type.
+    /// </summary>
+    /// <param name="eventType">Name of the topic to subscribe to.</param>
+    /// <param name="eventTypeImplementation">Type of the event implementation.</param>
+    /// <exception cref="ArgumentException">The topic name is not set.</exception>
+    public void SubscribeTo(Type eventType, Type eventTypeImplementation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventTypeImplementation.FullName);
+        SubscribeTo(eventType, eventTypeImplementation.FullName);
+    }
+
+    /// <summary>
     /// Instructs the topology to use provided topic to subscribe for events of a given type.
     /// </summary>
     /// <param name="topicName">Name of the topic to subscribe to.</param>


### PR DESCRIPTION
While writing the documentation for interface based inheritance I realized I have to write

```csharp
topology.SubscribeTo<IOrderStatusChanged>("Shipping.OrderStatusChanged");
```

even when I have the contracts available instead of 

```csharp
topology.SubscribeTo<IOrderStatusChanged, OrderStatusChanged>();
```