### PR TITLE
Fix minor issues with deserialization

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -211,10 +211,8 @@ namespace NServiceBus.Transport.AzureServiceBus
         [System.Runtime.CompilerServices.CompilerFeatureRequired("RequiredMembers")]
         public MigrationTopologyOptions() { }
         [NServiceBus.Transport.AzureServiceBus.ValidMigrationTopology]
-        [System.Text.Json.Serialization.JsonInclude]
         public System.Collections.Generic.HashSet<string> EventsToMigrateMap { get; init; }
         [NServiceBus.Transport.AzureServiceBus.AzureServiceBusRules]
-        [System.Text.Json.Serialization.JsonInclude]
         public System.Collections.Generic.Dictionary<string, string> SubscribedEventToRuleNameMap { get; init; }
         [NServiceBus.Transport.AzureServiceBus.AzureServiceBusTopics]
         [System.ComponentModel.DataAnnotations.Required]
@@ -252,15 +250,12 @@ namespace NServiceBus.Transport.AzureServiceBus
     {
         public TopologyOptions() { }
         [NServiceBus.Transport.AzureServiceBus.AzureServiceBusTopics]
-        [System.Text.Json.Serialization.JsonInclude]
         public System.Collections.Generic.Dictionary<string, string> PublishedEventToTopicsMap { get; init; }
         [NServiceBus.Transport.AzureServiceBus.AzureServiceBusQueues]
         [NServiceBus.Transport.AzureServiceBus.AzureServiceBusSubscriptions]
-        [System.Text.Json.Serialization.JsonInclude]
         public System.Collections.Generic.Dictionary<string, string> QueueNameToSubscriptionNameMap { get; init; }
         [NServiceBus.Transport.AzureServiceBus.AzureServiceBusTopics]
         [System.Text.Json.Serialization.JsonConverter(typeof(NServiceBus.Transport.AzureServiceBus.SubscribedEventToTopicsMapConverter))]
-        [System.Text.Json.Serialization.JsonInclude]
         public System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>> SubscribedEventToTopicsMap { get; init; }
     }
     public sealed class TopologyOptionsDisableValidationValidator : Microsoft.Extensions.Options.IValidateOptions<NServiceBus.Transport.AzureServiceBus.TopologyOptions>

--- a/src/Tests/EventRouting/SubscribeEventToTopicsMapConverterTests.cs
+++ b/src/Tests/EventRouting/SubscribeEventToTopicsMapConverterTests.cs
@@ -7,6 +7,71 @@ using NUnit.Framework;
 public class SubscribeEventToTopicsMapConverterTests
 {
     [Test]
+    public void Initializes_empty_collections_when_data_is_missing()
+    {
+        const string jsonPayload = """
+                                   {
+                                      "$type" : "topology-options"
+                                   }
+                                   """;
+
+        TopologyOptions deserialized =
+            JsonSerializer.Deserialize(jsonPayload, TopologyOptionsSerializationContext.Default.TopologyOptions);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized.PublishedEventToTopicsMap, Is.Not.Null);
+            Assert.That(deserialized.SubscribedEventToTopicsMap, Is.Not.Null);
+            Assert.That(deserialized.QueueNameToSubscriptionNameMap, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void Initializes_empty_collections_when_data_is_missing_migration_options()
+    {
+        const string jsonPayload = """
+                                   {
+                                      "$type" : "migration-topology-options",
+                                      "TopicToPublishTo" : "bundle-1",
+                                      "TopicToSubscribeOn" : "bundle-1"
+                                   }
+                                   """;
+
+        MigrationTopologyOptions deserialized =
+            JsonSerializer.Deserialize(jsonPayload, TopologyOptionsSerializationContext.Default.MigrationTopologyOptions);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized.PublishedEventToTopicsMap, Is.Not.Null);
+            Assert.That(deserialized.SubscribedEventToTopicsMap, Is.Not.Null);
+            Assert.That(deserialized.QueueNameToSubscriptionNameMap, Is.Not.Null);
+            Assert.That(deserialized.EventsToMigrateMap, Is.Not.Null);
+            Assert.That(deserialized.SubscribedEventToRuleNameMap, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void Can_provide_migration_topology_options_with_type_annotations()
+    {
+        const string jsonPayload = """
+                                   {
+                                      "$type" : "migration-topology-options",
+                                      "TopicToPublishTo" : "bundle-1",
+                                      "TopicToSubscribeOn" : "bundle-1"
+                                   }
+                                   """;
+
+        var deserialized = (MigrationTopologyOptions)
+            JsonSerializer.Deserialize(jsonPayload, TopologyOptionsSerializationContext.Default.TopologyOptions);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized.TopicToSubscribeOn, Is.EqualTo("bundle-1"));
+            Assert.That(deserialized.TopicToPublishTo, Is.EqualTo("bundle-1"));
+        });
+    }
+
+    [Test]
     public void Defaults_to_non_migration_when_no_type_specified()
     {
         const string jsonPayload = """

--- a/src/Tests/EventRouting/SubscribeEventToTopicsMapConverterTests.cs
+++ b/src/Tests/EventRouting/SubscribeEventToTopicsMapConverterTests.cs
@@ -7,6 +7,28 @@ using NUnit.Framework;
 public class SubscribeEventToTopicsMapConverterTests
 {
     [Test]
+    public void Defaults_to_non_migration_when_no_type_specified()
+    {
+        const string jsonPayload = """
+                                   {
+                                     "SubscribedEventToTopicsMap" : {
+                                       "MyEvent" : "SomeTopic"
+                                     }
+                                   }
+                                   """;
+
+        TopologyOptions deserialized =
+            JsonSerializer.Deserialize(jsonPayload, TopologyOptionsSerializationContext.Default.TopologyOptions);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized.SubscribedEventToTopicsMap, Has.Count.EqualTo(1));
+            Assert.That(deserialized.SubscribedEventToTopicsMap["MyEvent"],
+                Is.EquivalentTo(["SomeTopic"]));
+        });
+    }
+
+    [Test]
     public void Supports_single_element()
     {
         const string jsonPayload = """

--- a/src/Transport/EventRouting/MigrationTopologyOptions.cs
+++ b/src/Transport/EventRouting/MigrationTopologyOptions.cs
@@ -29,12 +29,24 @@ public sealed class MigrationTopologyOptions : TopologyOptions
     /// </summary>
     [JsonInclude]
     [ValidMigrationTopology]
-    public HashSet<string> EventsToMigrateMap { get; init; } = [];
+    public HashSet<string> EventsToMigrateMap
+    {
+        get => eventsToMigrateMap;
+        init => eventsToMigrateMap = value ?? [];
+    }
 
     /// <summary>
     /// Maps event full names to non-default rule names.
     /// </summary>
     [JsonInclude]
     [AzureServiceBusRules]
-    public Dictionary<string, string> SubscribedEventToRuleNameMap { get; init; } = [];
+    public Dictionary<string, string> SubscribedEventToRuleNameMap
+    {
+        get => subscribedEventToRuleNameMap;
+        init => subscribedEventToRuleNameMap = value ?? [];
+    }
+
+    //Backing fields are required because the Json serializes initializes properties to null if corresponding json element is missing
+    readonly HashSet<string> eventsToMigrateMap = [];
+    readonly Dictionary<string, string> subscribedEventToRuleNameMap = [];
 }

--- a/src/Transport/EventRouting/MigrationTopologyOptions.cs
+++ b/src/Transport/EventRouting/MigrationTopologyOptions.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Transport.AzureServiceBus;
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 /// <summary>
 /// Serializable object that defines the migration topology
@@ -27,7 +26,6 @@ public sealed class MigrationTopologyOptions : TopologyOptions
     /// <summary>
     /// Collection of events that have not yet been migrated to the topic-per-event topology
     /// </summary>
-    [JsonInclude]
     [ValidMigrationTopology]
     public HashSet<string> EventsToMigrateMap
     {
@@ -38,7 +36,6 @@ public sealed class MigrationTopologyOptions : TopologyOptions
     /// <summary>
     /// Maps event full names to non-default rule names.
     /// </summary>
-    [JsonInclude]
     [AzureServiceBusRules]
     public Dictionary<string, string> SubscribedEventToRuleNameMap
     {

--- a/src/Transport/EventRouting/TopologyOptions.cs
+++ b/src/Transport/EventRouting/TopologyOptions.cs
@@ -11,19 +11,16 @@ using System.Text.Json.Serialization;
 public class TopologyOptions
 {
     /// <summary>
-    /// Maps event type full names to topics under which they are to be published.
-    /// </summary>
-    [JsonInclude]
-    [AzureServiceBusTopics]
-    public Dictionary<string, string> PublishedEventToTopicsMap { get; init; } = [];
-
-    /// <summary>
     /// Maps event type full names to topics under which they are to be subscribed.
     /// </summary>
     [JsonInclude]
     [AzureServiceBusTopics]
     [JsonConverter(typeof(SubscribedEventToTopicsMapConverter))]
-    public Dictionary<string, HashSet<string>> SubscribedEventToTopicsMap { get; init; } = [];
+    public Dictionary<string, HashSet<string>> SubscribedEventToTopicsMap
+    {
+        get => subscribedEventToTopicsMap;
+        init => subscribedEventToTopicsMap = value ?? [];
+    }
 
     /// <summary>
     /// Maps queue names to non-default subscription names.
@@ -31,5 +28,25 @@ public class TopologyOptions
     [JsonInclude]
     [AzureServiceBusQueues]
     [AzureServiceBusSubscriptions]
-    public Dictionary<string, string> QueueNameToSubscriptionNameMap { get; init; } = [];
+    public Dictionary<string, string> QueueNameToSubscriptionNameMap
+    {
+        get => queueNameToSubscriptionNameMap;
+        init => queueNameToSubscriptionNameMap = value ?? [];
+    }
+
+    /// <summary>
+    /// Maps event type full names to topics under which they are to be published.
+    /// </summary>
+    [JsonInclude]
+    [AzureServiceBusTopics]
+    public Dictionary<string, string> PublishedEventToTopicsMap
+    {
+        get => publishedEventToTopicsMap;
+        init => publishedEventToTopicsMap = value ?? [];
+    }
+
+    //Backing fields are required because the Json serializes initializes properties to null if corresponding json element is missing
+    readonly Dictionary<string, string> publishedEventToTopicsMap = [];
+    readonly Dictionary<string, HashSet<string>> subscribedEventToTopicsMap = [];
+    readonly Dictionary<string, string> queueNameToSubscriptionNameMap = [];
 }

--- a/src/Transport/EventRouting/TopologyOptions.cs
+++ b/src/Transport/EventRouting/TopologyOptions.cs
@@ -11,9 +11,18 @@ using System.Text.Json.Serialization;
 public class TopologyOptions
 {
     /// <summary>
+    /// Maps event type full names to topics under which they are to be published.
+    /// </summary>
+    [AzureServiceBusTopics]
+    public Dictionary<string, string> PublishedEventToTopicsMap
+    {
+        get => publishedEventToTopicsMap;
+        init => publishedEventToTopicsMap = value ?? [];
+    }
+
+    /// <summary>
     /// Maps event type full names to topics under which they are to be subscribed.
     /// </summary>
-    [JsonInclude]
     [AzureServiceBusTopics]
     [JsonConverter(typeof(SubscribedEventToTopicsMapConverter))]
     public Dictionary<string, HashSet<string>> SubscribedEventToTopicsMap
@@ -25,24 +34,12 @@ public class TopologyOptions
     /// <summary>
     /// Maps queue names to non-default subscription names.
     /// </summary>
-    [JsonInclude]
     [AzureServiceBusQueues]
     [AzureServiceBusSubscriptions]
     public Dictionary<string, string> QueueNameToSubscriptionNameMap
     {
         get => queueNameToSubscriptionNameMap;
         init => queueNameToSubscriptionNameMap = value ?? [];
-    }
-
-    /// <summary>
-    /// Maps event type full names to topics under which they are to be published.
-    /// </summary>
-    [JsonInclude]
-    [AzureServiceBusTopics]
-    public Dictionary<string, string> PublishedEventToTopicsMap
-    {
-        get => publishedEventToTopicsMap;
-        init => publishedEventToTopicsMap = value ?? [];
     }
 
     //Backing fields are required because the Json serializes initializes properties to null if corresponding json element is missing


### PR DESCRIPTION
Adds handling of cases when a property was not included in the json document. Also adds more tests for some corner cases e.g.
 - Type annotation not provided
 - Type annotation pointing to migration topology
 - Properties missing from json