### PR TITLE
Use `IsDebugEnabled` to reduce costs of debug log events

### DIFF
--- a/src/Transport/Administration/QueueCreator.cs
+++ b/src/Transport/Administration/QueueCreator.cs
@@ -31,7 +31,10 @@ class QueueCreator(AzureServiceBusTransport transportSettings)
             }
             catch (ServiceBusException sbe) when (sbe.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
             {
-                Logger.Debug($"Queue {queue.Name} already exists");
+                if (Logger.IsDebugEnabled)
+                {
+                    Logger.Debug($"Queue {queue.Name} already exists");
+                }
             }
             catch (ServiceBusException sbe) when (sbe.IsTransient)// An operation is in progress.
             {

--- a/src/Transport/EventRouting/MigrationTopologyCreator.cs
+++ b/src/Transport/EventRouting/MigrationTopologyCreator.cs
@@ -79,7 +79,10 @@ sealed class MigrationTopologyCreator(AzureServiceBusTransport transportSettings
                 catch (ServiceBusException sbe) when
                     (sbe.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
                 {
-                    Logger.Debug($"Default subscription rule for topic {subscription.TopicName} already exists");
+                    if (Logger.IsDebugEnabled)
+                    {
+                        Logger.Debug($"Default subscription rule for topic {subscription.TopicName} already exists");
+                    }
                 }
                 catch (ServiceBusException sbe) when (sbe.IsTransient) // An operation is in progress.
                 {

--- a/src/Transport/EventRouting/MigrationTopologySubscriptionManager.cs
+++ b/src/Transport/EventRouting/MigrationTopologySubscriptionManager.cs
@@ -120,7 +120,10 @@ sealed class MigrationTopologySubscriptionManager : SubscriptionManager
         }
         catch (ServiceBusException sbe) when (sbe.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
         {
-            Logger.Debug($"Default subscription rule for topic {subscription.TopicName} already exists");
+            if (Logger.IsDebugEnabled)
+            {
+                Logger.Debug($"Default subscription rule for topic {subscription.TopicName} already exists");
+            }
         }
         catch (ServiceBusException sbe) when (sbe.IsTransient)// An operation is in progress.
         {

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -152,7 +152,10 @@ sealed class MessagePump(
         }
         catch (Exception ex) when (ex.IsCausedBy(messageProcessingCancellationTokenSource!.Token))
         {
-            Logger.Debug("Message processing canceled.", ex);
+            if (Logger.IsDebugEnabled)
+            {
+                Logger.Debug("Message processing canceled.", ex);
+            }
         }
     }
 
@@ -216,7 +219,10 @@ sealed class MessagePump(
         }
         catch (Exception ex) when (ex.IsCausedBy(cancellationToken))
         {
-            Logger.Debug($"Operation canceled while stopping the receiver {processor.EntityPath}.", ex);
+            if (Logger.IsDebugEnabled)
+            {
+                Logger.Debug($"Operation canceled while stopping the receiver {processor.EntityPath}.", ex);
+            }
         }
     }
 

--- a/src/Transport/Receiving/ProcessMessageEventArgsExtensions.cs
+++ b/src/Transport/Receiving/ProcessMessageEventArgsExtensions.cs
@@ -16,7 +16,10 @@ static class ProcessMessageEventArgsExtensions
     {
         if (transportTransactionMode == TransportTransactionMode.ReceiveOnly && messagesToBeCompleted.TryGet(message.GetMessageId(), out _))
         {
-            Logger.DebugFormat("Received message with id '{0}' was marked as successfully completed. Trying to immediately acknowledge the message without invoking the pipeline.", message.GetMessageId());
+            if (Logger.IsDebugEnabled)
+            {
+                Logger.DebugFormat("Received message with id '{0}' was marked as successfully completed. Trying to immediately acknowledge the message without invoking the pipeline.", message.GetMessageId());
+            }
 
             try
             {
@@ -56,8 +59,11 @@ static class ProcessMessageEventArgsExtensions
             }
             catch (Exception e) when (!e.IsCausedBy(cancellationToken))
             {
-                // nothing we can do about it, message will be retried
-                Logger.Debug($"Error abandoning the message with id '{message.GetMessageId()}' because the lock has expired at '{message.LockedUntil}.", e);
+                if (Logger.IsDebugEnabled)
+                {
+                    // nothing we can do about it, message will be retried
+                    Logger.Debug($"Error abandoning the message with id '{message.GetMessageId()}' because the lock has expired at '{message.LockedUntil}.", e);
+                }
             }
         }
         return false;
@@ -80,8 +86,11 @@ static class ProcessMessageEventArgsExtensions
             }
             catch (Exception deadLetterEx) when (!deadLetterEx.IsCausedBy(cancellationToken))
             {
-                // nothing we can do about it, message will be retried
-                Logger.Debug("Error dead lettering poisoned message.", deadLetterEx);
+                if (Logger.IsDebugEnabled)
+                {
+                    // nothing we can do about it, message will be retried
+                    Logger.Debug("Error dead lettering poisoned message.", deadLetterEx);
+                }
             }
         }
         else
@@ -126,9 +135,12 @@ static class ProcessMessageEventArgsExtensions
             }
             catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.MessageLockLost)
             {
-                // We tried to abandon the message because it needs to be retried, but the lock was lost.
-                // the message will reappear on the next receive anyway so we can just ignore this case.
-                Logger.DebugFormat("Attempted to abandon the message with id '{0}' but the lock was lost.", message.GetMessageId());
+                if (Logger.IsDebugEnabled)
+                {
+                    // We tried to abandon the message because it needs to be retried, but the lock was lost.
+                    // the message will reappear on the next receive anyway so we can just ignore this case.
+                    Logger.DebugFormat("Attempted to abandon the message with id '{0}' but the lock was lost.", message.GetMessageId());
+                }
             }
         }
     }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -221,7 +221,11 @@ class MessageDispatcher(
             // when it tries to establish a link to a non-existing entity.
             catch (ServiceBusException e) when (isMulticast && e.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
             {
-                Log.Debug($"Skipping sending messages to topic {destination} because the destination does not exist.");
+                if (Log.IsDebugEnabled)
+                {
+                    Log.Debug($"Skipping sending messages to topic {destination} because the destination does not exist.");
+                }
+
                 return;
             }
         }
@@ -299,7 +303,10 @@ class MessageDispatcher(
         }
         catch (ServiceBusException e) when (isMulticast && e.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
         {
-            Log.Debug($"Sending message with message ID '{message.MessageId}' to topic {destination} failed because the destination does not exist.");
+            if (Log.IsDebugEnabled)
+            {
+                Log.Debug($"Sending message with message ID '{message.MessageId}' to topic {destination} failed because the destination does not exist.");
+            }
         }
     }
 }


### PR DESCRIPTION
ILogger.Debug() calls that use string interpolation or invoking methods to get log arguments wrapped in `IsDebugEnabled`

The actual improvement would be to remove all string interpolation and use log template via the `.****Format` methods but that is a lot of work.