### PR TITLE
Improve exception messages for connectivity exceptions

### DIFF
--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -51,7 +51,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var sender = new FakeSender
             {
@@ -75,7 +75,9 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client),
+            var dispatcher = new MessageDispatcher(
+                client,
+                new MessageSenderRegistry(),
                 TopicTopology.FromOptions(new TopologyOptions
                 {
                     PublishedEventToTopicsMap = { { typeof(SomeEvent).FullName, "sometopic" } }
@@ -114,7 +116,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client), TopicTopology.FromOptions(new TopologyOptions()
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()
             {
                 PublishedEventToTopicsMap = { { typeof(SomeEvent).FullName, "sometopic" } }
             }));
@@ -150,7 +152,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -188,7 +190,9 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client),
+            var dispatcher = new MessageDispatcher(
+                client,
+                new MessageSenderRegistry(),
                 TopicTopology.FromOptions(new TopologyOptions
                 {
                     PublishedEventToTopicsMap =
@@ -230,7 +234,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -266,7 +270,9 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client),
+            var dispatcher = new MessageDispatcher(
+                client,
+                new MessageSenderRegistry(),
                 TopicTopology.FromOptions(new TopologyOptions
                 {
                     PublishedEventToTopicsMap = { { typeof(SomeEvent).FullName, "sometopic" } }
@@ -306,7 +312,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -354,7 +360,9 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client),
+            var dispatcher = new MessageDispatcher(
+                client,
+                new MessageSenderRegistry(),
                 TopicTopology.FromOptions(new TopologyOptions
                 {
                     PublishedEventToTopicsMap =
@@ -409,7 +417,9 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         {
             var client = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(client),
+            var dispatcher = new MessageDispatcher(
+                client,
+                new MessageSenderRegistry(),
                 TopicTopology.FromOptions(new TopologyOptions
                 {
                     PublishedEventToTopicsMap =
@@ -491,7 +501,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
             defaultClient.Senders["SomeDestination"] = defaultSender;
             var transactionalClient = new FakeServiceBusClient();
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(defaultClient), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -543,7 +553,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                 return false;
             };
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(defaultClient), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var nrOfMessages = 150;
             var operations = new List<TransportOperation>(nrOfMessages);
@@ -587,7 +597,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                 return false;
             };
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(defaultClient), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operations = new List<TransportOperation>(200);
             for (int i = 0; i < 200; i++)
@@ -624,7 +634,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
 
             defaultSender.TryAdd = msg => false;
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(defaultClient), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operations = new List<TransportOperation>(5);
             for (int i = 0; i < 5; i++)
@@ -666,7 +676,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                 };
             };
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(defaultClient), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operations = new List<TransportOperation>(5);
             for (int i = 0; i < 10; i++)
@@ -699,7 +709,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
             var transactionalSender = new FakeSender();
             transactionalClient.Senders["SomeDestination"] = transactionalSender;
 
-            var dispatcher = new MessageDispatcher(new MessageSenderRegistry(defaultClient), TopicTopology.FromOptions(new TopologyOptions()));
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",

--- a/src/Tests/Sending/MessageRegistryTests.cs
+++ b/src/Tests/Sending/MessageRegistryTests.cs
@@ -10,16 +10,17 @@
         [Test]
         public async Task Should_get_cached_sender_per_destination()
         {
-            var pool = new MessageSenderRegistry(new ServiceBusClient(FakeConnectionString));
+            var client = new ServiceBusClient(FakeConnectionString);
+            var pool = new MessageSenderRegistry();
 
             try
             {
-                var firstMessageSenderDest1 = pool.GetMessageSender("dest1", null);
+                var firstMessageSenderDest1 = pool.GetMessageSender("dest1", client);
 
-                var firstMessageSenderDest2 = pool.GetMessageSender("dest2", null);
+                var firstMessageSenderDest2 = pool.GetMessageSender("dest2", client);
 
-                var secondMessageSenderDest1 = pool.GetMessageSender("dest1", null);
-                var secondMessageSenderDest2 = pool.GetMessageSender("dest2", null);
+                var secondMessageSenderDest1 = pool.GetMessageSender("dest1", client);
+                var secondMessageSenderDest2 = pool.GetMessageSender("dest2", client);
 
                 Assert.Multiple(() =>
                 {

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -33,9 +33,10 @@ sealed class AzureServiceBusTransportInfrastructure : TransportInfrastructure
         this.administrationClient = administrationClient;
         this.receiveSettingsAndClientPairs = receiveSettingsAndClientPairs;
 
-        messageSenderRegistry = new MessageSenderRegistry(defaultClient);
+        messageSenderRegistry = new MessageSenderRegistry();
 
         Dispatcher = new MessageDispatcher(
+            defaultClient,
             messageSenderRegistry,
             transportSettings.Topology,
             transportSettings.OutgoingNativeMessageCustomization

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -10,6 +10,7 @@ using Azure.Messaging.ServiceBus;
 using Logging;
 
 class MessageDispatcher(
+    ServiceBusClient defaultClient,
     MessageSenderRegistry messageSenderRegistry,
     TopicTopology topology,
     OutgoingNativeMessageCustomizationAction? customizerCallback = null)
@@ -147,6 +148,7 @@ class MessageDispatcher(
     {
         int batchCount = 0;
         List<ServiceBusMessage>? messagesTooLargeToBeBatched = null;
+        client ??= defaultClient;
         var sender = messageSenderRegistry.GetMessageSender(destination, client);
         while (messagesToSend.Count > 0)
         {
@@ -227,6 +229,19 @@ class MessageDispatcher(
 
                 return;
             }
+            catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)
+            {
+                if (client.TransportType == ServiceBusTransportType.AmqpTcp)
+                {
+                    throw new Exception("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets", e);
+                }
+                else if (client.TransportType == ServiceBusTransportType.AmqpWebSockets)
+                {
+                    throw new Exception("Couldn't connect using web sockets.", e);
+                }
+
+                throw;
+            }
         }
 
         if (messagesTooLargeToBeBatched is not null)
@@ -292,6 +307,7 @@ class MessageDispatcher(
     async Task DispatchForDestination(string destination, bool isMulticast, ServiceBusClient? client,
         Transaction? transaction, ServiceBusMessage message, CancellationToken cancellationToken)
     {
+        client ??= defaultClient;
         var sender = messageSenderRegistry.GetMessageSender(destination, client);
         try
         {
@@ -306,6 +322,19 @@ class MessageDispatcher(
             {
                 Log.Debug($"Sending message with message ID '{message.MessageId}' to topic {destination} failed because the destination does not exist.");
             }
+        }
+        catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)
+        {
+            if (client.TransportType == ServiceBusTransportType.AmqpTcp)
+            {
+                throw new Exception("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets", e);
+            }
+            else if (client.TransportType == ServiceBusTransportType.AmqpWebSockets)
+            {
+                throw new Exception("Couldn't connect using web sockets.", e);
+            }
+
+            throw;
         }
     }
 }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -233,11 +233,11 @@ class MessageDispatcher(
             {
                 if (client.TransportType == ServiceBusTransportType.AmqpTcp)
                 {
-                    Log.Error("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets");
+                    Log.Error("Couldn't connect using AMQP over TCP. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets");
                 }
                 else if (client.TransportType == ServiceBusTransportType.AmqpWebSockets)
                 {
-                    Log.Error("Couldn't connect using web sockets.");
+                    Log.Error("Couldn't connect using AMQP over web sockets.");
                 }
 
                 throw;
@@ -327,11 +327,11 @@ class MessageDispatcher(
         {
             if (client.TransportType == ServiceBusTransportType.AmqpTcp)
             {
-                Log.Error("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets");
+                Log.Error("Couldn't connect using AMQP over TCP. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets");
             }
             else if (client.TransportType == ServiceBusTransportType.AmqpWebSockets)
             {
-                Log.Error("Couldn't connect using web sockets.");
+                Log.Error("Couldn't connect using AMQP over web sockets.");
             }
 
             throw;

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -233,11 +233,11 @@ class MessageDispatcher(
             {
                 if (client.TransportType == ServiceBusTransportType.AmqpTcp)
                 {
-                    throw new Exception("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets", e);
+                    Log.Error("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets");
                 }
                 else if (client.TransportType == ServiceBusTransportType.AmqpWebSockets)
                 {
-                    throw new Exception("Couldn't connect using web sockets.", e);
+                    Log.Error("Couldn't connect using web sockets.");
                 }
 
                 throw;
@@ -327,11 +327,11 @@ class MessageDispatcher(
         {
             if (client.TransportType == ServiceBusTransportType.AmqpTcp)
             {
-                throw new Exception("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets", e);
+                Log.Error("Couldn't connect using AMQP protocol. Ensure AMQP ports 5671 and 5672 on the server are reachable, or try using websockets");
             }
             else if (client.TransportType == ServiceBusTransportType.AmqpWebSockets)
             {
-                throw new Exception("Couldn't connect using web sockets.", e);
+                Log.Error("Couldn't connect using web sockets.");
             }
 
             throw;

--- a/src/Transport/Sending/MessageSenderRegistry.cs
+++ b/src/Transport/Sending/MessageSenderRegistry.cs
@@ -7,14 +7,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 
-sealed class MessageSenderRegistry(ServiceBusClient defaultClient)
+sealed class MessageSenderRegistry
 {
-    public ServiceBusSender GetMessageSender(string destination, ServiceBusClient? client)
+    public ServiceBusSender GetMessageSender(string destination, ServiceBusClient client)
     {
         // According to the client SDK guidelines we can safely use these client objects for concurrent asynchronous
         // operations and from multiple threads.
         // see https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-performance-improvements
-        var lazySender = destinationToSenderMapping.GetOrAdd((destination, client ?? defaultClient),
+        var lazySender = destinationToSenderMapping.GetOrAdd((destination, client),
             static arg =>
             {
                 (string innerDestination, ServiceBusClient innerClient) = arg;


### PR DESCRIPTION
Addresses:

- #1141 

In order to provide additional context to connectivity exceptions to ASB, the `MessageDispatcher` class needs access to the `ServiceBusClient` instance that was used to connect, so it can determine whether TCP or WebSockets was used.  For this reason, the default `ServiceBusClient` instance is provided to the `MessageDispatcher` class instead of `MessageSenderRegistry`, and it is the `MessageDispatcher` that coalesces any null client parameter to the default client.