### PR TITLE
[Backport to 5.0] The ContentType ServiceBusReceivedMessage is lost when messages are retried by ServiceControl because the transport doesn't propagate it to the NServiceBus ContentType header

### DIFF
--- a/src/Tests/Receiving/MessageExtensionsTests.cs
+++ b/src/Tests/Receiving/MessageExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
+{
+    using System.Collections.Generic;
+    using Azure.Messaging.ServiceBus;
+    using NServiceBus.Transport.AzureServiceBus.Configuration;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MessageExtensionsTests
+    {
+        [Test]
+        public void Should_extract_headers()
+        {
+            var message = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId",
+                contentType: "SomeContentType",
+                properties: new Dictionary<string, object>
+                {
+                    ["NServiceBus.Transport.Encoding"] = "SomeEncoding",
+                    ["Property1"] = "SomeProperty1"
+                }, replyTo: "SomeReplyTo", correlationId: "SomeCorrelationId");
+
+            var headers = message.GetNServiceBusHeaders();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(headers.ContainsKey(TransportMessageHeaders.TransportEncoding), Is.False);
+                Assert.That(headers["Property1"], Is.EqualTo("SomeProperty1"));
+                Assert.That(headers[Headers.ReplyToAddress], Is.EqualTo("SomeReplyTo"));
+                Assert.That(headers[Headers.CorrelationId], Is.EqualTo("SomeCorrelationId"));
+                Assert.That(headers[Headers.ContentType], Is.EqualTo("SomeContentType"));
+            });
+        }
+    }
+}

--- a/src/Transport/Receiving/MessageExtensions.cs
+++ b/src/Transport/Receiving/MessageExtensions.cs
@@ -30,6 +30,11 @@ static class MessageExtensions
             headers[Headers.CorrelationId] = message.CorrelationId;
         }
 
+        if (!string.IsNullOrWhiteSpace(message.ContentType))
+        {
+            headers[Headers.ContentType] = message.ContentType;
+        }
+
         return headers;
     }
 


### PR DESCRIPTION
This PR backports the fix for the following bug to version 5.0:

- https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/1254

(cherry picked from commit f2163e73860effd074b1437bb26f076106272914)