### PR TITLE
Add proper support for Azure Service Bus Emulator for development and testing

### DIFF
--- a/src/Tests/Administration/QueueCreatorTests.cs
+++ b/src/Tests/Administration/QueueCreatorTests.cs
@@ -27,6 +27,24 @@ public class QueueCreatorTests
     }
 
     [Test]
+    public async Task Should_use_configured_MaxDeliveryCount()
+    {
+        var transport = new AzureServiceBusTransport("connectionString", TopicTopology.Default)
+        {
+            MaxDeliveryCount = 10
+        };
+
+        var recordingClient = new RecordingServiceBusAdministrationClient();
+        var creator = new QueueCreator(transport);
+
+        await creator.Create(recordingClient, ["test-queue"], "test-queue");
+
+        var output = recordingClient.ToString();
+
+        Approver.Verify(output);
+    }
+
+    [Test]
     public async Task Should_not_set_AutoDeleteOnIdle_when_null()
     {
         var transport = new AzureServiceBusTransport("connectionString", TopicTopology.Default)

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -16,10 +16,12 @@ namespace NServiceBus
             "ersion 6.0.0.", true)]
         public AzureServiceBusTransport(string fullyQualifiedNamespace, Azure.Core.TokenCredential tokenCredential) { }
         public AzureServiceBusTransport(string fullyQualifiedNamespace, Azure.Core.TokenCredential tokenCredential, NServiceBus.TopicTopology topology) { }
+        public Azure.Messaging.ServiceBus.Administration.ServiceBusAdministrationClientOptions? AdministrationClientOptions { get; set; }
         public System.TimeSpan? AutoDeleteOnIdle { get; set; }
         public bool EnablePartitioning { get; set; }
         public int EntityMaximumSize { get; set; }
         public System.TimeSpan? MaxAutoLockRenewalDuration { get; set; }
+        public int MaxDeliveryCount { get; set; }
         public System.Action<NServiceBus.Transport.IOutgoingTransportOperation, Azure.Messaging.ServiceBus.ServiceBusMessage>? OutgoingNativeMessageCustomization { get; set; }
         public int? PrefetchCount { get; set; }
         public int PrefetchMultiplier { get; set; }

--- a/src/Tests/ApprovalFiles/QueueCreatorTests.Should_use_configured_MaxDeliveryCount.approved.txt
+++ b/src/Tests/ApprovalFiles/QueueCreatorTests.Should_use_configured_MaxDeliveryCount.approved.txt
@@ -1,0 +1,20 @@
+CreateQueueOptions: {
+  "Name": "test-queue",
+  "LockDuration": "00:05:00",
+  "MaxSizeInMegabytes": 5120,
+  "RequiresDuplicateDetection": false,
+  "RequiresSession": false,
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "DeadLetteringOnMessageExpiration": false,
+  "DuplicateDetectionHistoryTimeWindow": "00:01:00",
+  "MaxDeliveryCount": 10,
+  "EnableBatchedOperations": true,
+  "AuthorizationRules": [],
+  "Status": {},
+  "ForwardTo": null,
+  "ForwardDeadLetteredMessagesTo": null,
+  "EnablePartitioning": false,
+  "UserMetadata": null,
+  "MaxMessageSizeInKilobytes": null
+}

--- a/src/Transport/Administration/QueueCreator.cs
+++ b/src/Transport/Administration/QueueCreator.cs
@@ -20,7 +20,7 @@ class QueueCreator(AzureServiceBusTransport transportSettings)
             {
                 EnableBatchedOperations = true,
                 LockDuration = TimeSpan.FromMinutes(5),
-                MaxDeliveryCount = int.MaxValue,
+                MaxDeliveryCount = transportSettings.MaxDeliveryCount,
                 MaxSizeInMegabytes = transportSettings.EntityMaximumSizeInMegabytes,
                 EnablePartitioning = transportSettings.EnablePartitioning
             };

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -89,7 +89,8 @@ sealed class AzureServiceBusTransportInfrastructure : TransportInfrastructure
                     EnablePartitioning = transportSettings.EnablePartitioning,
                     SetupInfrastructure = hostSettings.SetupInfrastructure,
                     SubscribingQueueName = receiveAddress,
-                    EntityMaximumSizeInMegabytes = transportSettings.EntityMaximumSizeInMegabytes
+                    EntityMaximumSizeInMegabytes = transportSettings.EntityMaximumSizeInMegabytes,
+                    MaxDeliveryCount = transportSettings.MaxDeliveryCount
                 })
                 : null,
             subQueue

--- a/src/Transport/EventRouting/MigrationTopologyCreator.cs
+++ b/src/Transport/EventRouting/MigrationTopologyCreator.cs
@@ -65,7 +65,7 @@ sealed class MigrationTopologyCreator(AzureServiceBusTransport transportSettings
                         LockDuration = TimeSpan.FromMinutes(5),
                         ForwardTo = migrationTopology.TopicToSubscribeOn,
                         EnableDeadLetteringOnFilterEvaluationExceptions = false,
-                        MaxDeliveryCount = int.MaxValue,
+                        MaxDeliveryCount = transportSettings.MaxDeliveryCount,
                         EnableBatchedOperations = true,
                         UserMetadata = migrationTopology.TopicToSubscribeOn
                     };

--- a/src/Transport/EventRouting/MigrationTopologySubscriptionManager.cs
+++ b/src/Transport/EventRouting/MigrationTopologySubscriptionManager.cs
@@ -108,7 +108,7 @@ sealed class MigrationTopologySubscriptionManager : SubscriptionManager
             LockDuration = TimeSpan.FromMinutes(5),
             ForwardTo = CreationOptions.SubscribingQueueName,
             EnableDeadLetteringOnFilterEvaluationExceptions = false,
-            MaxDeliveryCount = int.MaxValue,
+            MaxDeliveryCount = CreationOptions.MaxDeliveryCount,
             EnableBatchedOperations = true,
             UserMetadata = CreationOptions.SubscribingQueueName
         };

--- a/src/Transport/EventRouting/SubscriptionManagerCreationOptions.cs
+++ b/src/Transport/EventRouting/SubscriptionManagerCreationOptions.cs
@@ -16,4 +16,6 @@ sealed class SubscriptionManagerCreationOptions
     public int EntityMaximumSizeInMegabytes { get; init; }
 
     public bool SetupInfrastructure { get; init; }
+
+    public int MaxDeliveryCount { get; init; } = int.MaxValue;
 }

--- a/src/Transport/EventRouting/TopicPerEventTopologySubscriptionManager.cs
+++ b/src/Transport/EventRouting/TopicPerEventTopologySubscriptionManager.cs
@@ -91,7 +91,7 @@ sealed class TopicPerEventTopologySubscriptionManager : SubscriptionManager
                 LockDuration = TimeSpan.FromMinutes(5),
                 ForwardTo = creationOptions.SubscribingQueueName,
                 EnableDeadLetteringOnFilterEvaluationExceptions = false,
-                MaxDeliveryCount = int.MaxValue,
+                MaxDeliveryCount = creationOptions.MaxDeliveryCount,
                 EnableBatchedOperations = true,
                 UserMetadata = creationOptions.SubscribingQueueName
             };


### PR DESCRIPTION
Add support for configuring MaxDeliveryCount and AdministrationClientOptions
Related issue #1104

This has been tested and verified on services running on version 5.1.2 of NServiceBus.Transport.AzureServiceBus (as we're not yet on .net 10, we cannot update to 6+ yet)

Questions for the maintainers: Do you want me to also implement the changes as a separate pullrequest on the latest code?

---

Since Azure Service Bus emulator now exposes the management API, the emulator should now be possible to fully replace learning transport or real azure service bus for testing and development purposes. (Jeremy Miller writes about it here: https://jeremydmiller.com/2026/02/19/using-the-azure-service-bus-emulator-for-local-wolverine-development/)

The emulator exposes the management api on a separate endpoint, so in order to use it it requires the endpoint adress to be explicitly configurable.

Additionally, the Azure Service Bus emulator imposes constraints not present in the real service: it caps MaxDeliveryCount at 10.

- Add `MaxDeliveryCount` property to `AzureServiceBusTransport` (defaults to `int.MaxValue` for backwards compatibility) and apply it consistently when creating queues and subscriptions across all topology creators and subscription managers.

- Add `AdministrationClientOptions` property to allow consumers to customise the `ServiceBusAdministrationClient`, e.g. to provide a custom HTTP transport redirecting requests to a non-TLS emulator endpoint or an Endpoint connectionstring as exposed by Azure Service Bus Emulator.

Fixes startup failures when using the Azure Service Bus emulator with `SetupInfrastructure = true`.