### PR TITLE
Add support for the Azure Service Bus emulator running on default ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
         uses: azure/login@v3.0.0
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
+      - name: Setup Azure Service Bus Emulator
+        uses: Particular/setup-azureservicebus-action@v1.4.0
+        with:
+          connection-string-name: AzureServiceBus_Emulator_ConnectionString
+          azure-credentials: ${{ secrets.AZURE_ACI_CREDENTIALS }}
+          tag: ASBTransport          
       - name: Setup Azure Service Bus
         uses: Particular/setup-azureservicebus-action@v2.0.0
         with:

--- a/src/Emulator.AcceptanceTests/.editorconfig
+++ b/src/Emulator.AcceptanceTests/.editorconfig
@@ -1,0 +1,11 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+
+# Justification: Cancellation may not be needed in test project
+dotnet_diagnostic.PS0018.severity = suggestion
+dotnet_diagnostic.PS0013.severity = suggestion
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/Emulator.AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
+++ b/src/Emulator.AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting.Customization;
+using NServiceBus.AcceptanceTesting.Support;
+using NServiceBus.MessageMutator;
+using NServiceBus.Transport.AzureServiceBus.AcceptanceTests;
+using NUnit.Framework;
+
+public class ConfigureEndpointAzureServiceBusTransport : IConfigureEndpointTestExecution
+{
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
+    {
+        var connectionString = (string)TestContext.CurrentContext.Test.Parent?.Properties.Get("AzureServiceBus_Emulator_ConnectionString")!;
+
+        var topology = TopicTopology.Default;
+        topology.OverrideSubscriptionNameFor(endpointName, endpointName.Shorten());
+
+        foreach (var eventType in publisherMetadata.Publishers.SelectMany(p => p.Events))
+        {
+            topology.PublishTo(eventType, eventType.ToTopicName());
+            topology.SubscribeTo(eventType, eventType.ToTopicName());
+        }
+
+        var transport = new AzureServiceBusTransport(connectionString, topology);
+
+        configuration.UseTransport(transport);
+
+        configuration.RegisterComponents(c => c.AddSingleton<IMutateOutgoingTransportMessages, TestIndependenceMutator>());
+        configuration.Pipeline.Register("TestIndependenceBehavior", typeof(TestIndependenceSkipBehavior), "Skips messages not created during the current test.");
+
+        configuration.EnforcePublisherMetadataRegistration(endpointName, publisherMetadata);
+
+        return Task.CompletedTask;
+    }
+
+    public Task Cleanup() => Task.CompletedTask;
+}

--- a/src/Emulator.AcceptanceTests/NServiceBus.Transport.AzureServiceBus.Emulator.AcceptanceTests.csproj
+++ b/src/Emulator.AcceptanceTests/NServiceBus.Transport.AzureServiceBus.Emulator.AcceptanceTests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Transport\NServiceBus.Transport.AzureServiceBus.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.0" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">
+    <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\**\*.cs" />
+    <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\**\EndpointTemplates\*.cs" />
+    <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\**\NServiceBusAcceptanceTest.cs" />
+    <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\**\ConfigureEndpointAcceptanceTestingPersistence.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AcceptanceTests\AcceptanceTestExtensions.cs" Link="AcceptanceTestExtensions.cs" />
+    <Compile Include="..\AcceptanceTests\TestIndependenceMutator.cs" Link="TestIndependenceMutator.cs" />
+    <Compile Include="..\AcceptanceTests\TestIndependenceSkipBehavior.cs" Link="TestIndependenceSkipBehavior.cs" />
+    <Compile Include="..\AcceptanceTests\TestSuiteConstraints.cs" Link="TestSuiteConstraints.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Emulator.AcceptanceTests/RunOnlyWithEmulatorAttribute.cs
+++ b/src/Emulator.AcceptanceTests/RunOnlyWithEmulatorAttribute.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus.Transport.AzureServiceBus.Emulator.AcceptanceTests;
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+public sealed class RunOnlyWithEmulatorAttribute : Attribute, IApplyToContext
+{
+    public void ApplyToContext(TestExecutionContext context)
+    {
+        var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus_Emulator_ConnectionString");
+
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            Assert.Ignore("No emulator connection string found. Set the AzureServiceBus_Emulator_ConnectionString environment variable to run these tests.");
+        }
+        else
+        {
+            context.CurrentTest.Properties.Set("AzureServiceBus_Emulator_ConnectionString", connectionString);
+        }
+    }
+}

--- a/src/Emulator.AcceptanceTests/When_publishing_a_message.cs
+++ b/src/Emulator.AcceptanceTests/When_publishing_a_message.cs
@@ -1,0 +1,46 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.Emulator.AcceptanceTests;
+
+using NServiceBus.AcceptanceTests;
+
+using System.Threading.Tasks;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NUnit.Framework;
+
+[RunOnlyWithEmulator]
+public class When_publishing_a_message : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_receive_it()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<Endpoint>(b => b.When(
+                (session, c) => session.Publish(new MyEvent())))
+            .Run();
+
+        Assert.That(context.EventReceived, Is.True);
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool EventReceived { get; set; }
+    }
+
+    public class Endpoint : EndpointConfigurationBuilder
+    {
+        public Endpoint() =>
+            EndpointSetup<DefaultServer>(c => { }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
+
+        public class Handler(Context testContext) : IHandleMessages<MyEvent>
+        {
+            public Task Handle(MyEvent request, IMessageHandlerContext context)
+            {
+                testContext.EventReceived = true;
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class MyEvent : IEvent;
+}

--- a/src/Emulator.AcceptanceTests/When_sending_a_message.cs
+++ b/src/Emulator.AcceptanceTests/When_sending_a_message.cs
@@ -1,0 +1,46 @@
+﻿namespace NServiceBus.Transport.AzureServiceBus.Emulator.AcceptanceTests;
+
+using NServiceBus.AcceptanceTests;
+
+using System.Threading.Tasks;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NUnit.Framework;
+
+[RunOnlyWithEmulator]
+public class When_sending_a_message : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_receive_it()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<Endpoint>(b => b.When(
+                (session, c) => session.SendLocal(new Message())))
+            .Run();
+
+        Assert.That(context.MessageReceived, Is.True);
+    }
+
+    public class Context : ScenarioContext
+    {
+        public bool MessageReceived { get; set; }
+    }
+
+    public class Endpoint : EndpointConfigurationBuilder
+    {
+        public Endpoint() =>
+            EndpointSetup<DefaultServer>();
+
+        public class Handler(Context testContext) : IHandleMessages<Message>
+        {
+            public Task Handle(Message request, IMessageHandlerContext context)
+            {
+                testContext.MessageReceived = true;
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class Message : IMessage;
+}

--- a/src/Emulator.AcceptanceTests/When_sending_multiple_messages.cs
+++ b/src/Emulator.AcceptanceTests/When_sending_multiple_messages.cs
@@ -1,0 +1,114 @@
+namespace NServiceBus.Transport.AzureServiceBus.Emulator.AcceptanceTests;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Customization;
+using NServiceBus.AcceptanceTests;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NServiceBus.Logging;
+using NUnit.Framework;
+
+[RunOnlyWithEmulator]
+public class When_sending_multiple_messages : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_receive_them()
+    {
+        var kickOffMessageId = Guid.NewGuid().ToString();
+
+        var listOfMessagesForBatching = new List<string>();
+        for (var i = 0; i < 50; i++)
+        {
+            listOfMessagesForBatching.Add(Guid.NewGuid().ToString());
+        }
+
+        var listOfMessagesForImmediateDispatch = new List<string>();
+        for (var i = 0; i < 10; i++)
+        {
+            listOfMessagesForImmediateDispatch.Add(Guid.NewGuid().ToString());
+        }
+
+        var context = await Scenario.Define<Context>(c =>
+            {
+
+                c.LogLevel = LogLevel.Debug;
+                c.MessageIdsForBatching = listOfMessagesForBatching;
+                c.MessageIdsForImmediateDispatch = listOfMessagesForImmediateDispatch;
+                c.AllMessageIds = new ConcurrentDictionary<string, string>(listOfMessagesForBatching.Union(listOfMessagesForImmediateDispatch).ToDictionary(x => x, x => x));
+            })
+            .WithEndpoint<Sender>(b => b.When(session =>
+            {
+                var options = new SendOptions();
+                options.RouteToThisEndpoint();
+                options.SetMessageId(kickOffMessageId);
+
+                return session.Send(new SendMessagesInBatches(), options);
+            }))
+            .WithEndpoint<Receiver>()
+            .Run();
+
+        Assert.That(context.AllMessageIds, Is.Empty, "All messages should have been received");
+    }
+
+    public class Context : ScenarioContext
+    {
+        public List<string> MessageIdsForBatching { get; set; }
+        public List<string> MessageIdsForImmediateDispatch { get; set; }
+        public ConcurrentDictionary<string, string> AllMessageIds { get; set; }
+    }
+
+    public class Sender : EndpointConfigurationBuilder
+    {
+        public Sender() =>
+            EndpointSetup<DefaultServer>(builder =>
+            {
+                builder.ConfigureRouting().RouteToEndpoint(typeof(MyMessage), typeof(Receiver));
+            });
+
+        public class BatchHandler(Context testContext) : IHandleMessages<SendMessagesInBatches>
+        {
+            public async Task Handle(SendMessagesInBatches message, IMessageHandlerContext context)
+            {
+                foreach (var messageId in testContext.MessageIdsForBatching)
+                {
+                    var options = new SendOptions();
+                    options.SetMessageId(messageId);
+
+                    await context.Send(new MyMessage(), options);
+                }
+
+                foreach (var messageId in testContext.MessageIdsForImmediateDispatch)
+                {
+                    var options = new SendOptions();
+                    options.SetMessageId(messageId);
+                    options.RequireImmediateDispatch();
+
+                    await context.Send(new MyMessage(), options);
+                }
+            }
+        }
+    }
+
+    public class Receiver : EndpointConfigurationBuilder
+    {
+        public Receiver() => EndpointSetup<DefaultServer>(c => c.LimitMessageProcessingConcurrencyTo(60));
+
+        public class MyMessageHandler(Context testContext) : IHandleMessages<MyMessage>
+        {
+            public Task Handle(MyMessage messageWithLargePayload, IMessageHandlerContext context)
+            {
+                testContext.AllMessageIds.TryRemove(context.MessageId, out _);
+                testContext.MarkAsCompleted(testContext.AllMessageIds.IsEmpty);
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class SendMessagesInBatches : ICommand;
+
+    public class MyMessage : ICommand;
+}

--- a/src/NServiceBus.Transport.AzureServiceBus.slnx
+++ b/src/NServiceBus.Transport.AzureServiceBus.slnx
@@ -7,6 +7,7 @@
   <Folder Name="/Tests/">
     <Project Path="AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj" />
     <Project Path="CommandLineTests/NServiceBus.Transport.AzureServiceBus.CommandLine.Tests.csproj" />
+    <Project Path="Emulator.AcceptanceTests/NServiceBus.Transport.AzureServiceBus.Emulator.AcceptanceTests.csproj" />
     <Project Path="MigrationAcceptanceTests/NServiceBus.Transport.AzureServiceBus.Migration.AcceptanceTests.csproj" />
     <Project Path="Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj" />
     <Project Path="TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj" />

--- a/src/Tests/Administration/QueueCreatorTests.cs
+++ b/src/Tests/Administration/QueueCreatorTests.cs
@@ -100,4 +100,34 @@ public class QueueCreatorTests
 
         Approver.Verify(output);
     }
+
+    [Test]
+    public async Task Should_set_MaxDeliveryCount_to_max_int_when_not_using_emulator()
+    {
+        var transport = new AzureServiceBusTransport("connection-string", TopicTopology.Default);
+
+        var recordingClient = new RecordingServiceBusAdministrationClient();
+        var creator = new QueueCreator(transport);
+
+        await creator.Create(recordingClient, ["test-queue"], null);
+
+        var output = recordingClient.ToString();
+
+        Approver.Verify(output);
+    }
+
+    [Test]
+    public async Task Should_set_MaxDeliveryCount_to_10_when_using_emulator()
+    {
+        var transport = new AzureServiceBusTransport("UseDevelopmentEmulator=true", TopicTopology.Default);
+
+        var recordingClient = new RecordingServiceBusAdministrationClient();
+        var creator = new QueueCreator(transport);
+
+        await creator.Create(recordingClient, ["test-queue"], null);
+
+        var output = recordingClient.ToString();
+
+        Approver.Verify(output);
+    }
 }

--- a/src/Tests/ApprovalFiles/MigrationTopologyTests.Should_set_MaxDeliveryCount_to_10_when_using_emulator.approved.txt
+++ b/src/Tests/ApprovalFiles/MigrationTopologyTests.Should_set_MaxDeliveryCount_to_10_when_using_emulator.approved.txt
@@ -1,0 +1,25 @@
+CreateSubscriptionOptions: {
+  "LockDuration": "00:05:00",
+  "RequiresSession": false,
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "DeadLetteringOnMessageExpiration": false,
+  "EnableDeadLetteringOnFilterEvaluationExceptions": false,
+  "TopicName": "bundle-1",
+  "SubscriptionName": "MySub",
+  "MaxDeliveryCount": 10,
+  "Status": {},
+  "ForwardTo": "SubscribingQueue",
+  "ForwardDeadLetteredMessagesTo": null,
+  "EnableBatchedOperations": true,
+  "UserMetadata": "SubscribingQueue"
+}
+CreateRuleOptions: {
+  "Filter": {
+    "filter-type": "false",
+    "SqlExpression": "1=0",
+    "Parameters": {}
+  },
+  "Action": null,
+  "Name": "$default"
+}

--- a/src/Tests/ApprovalFiles/MigrationTopologyTests.Should_set_MaxDeliveryCount_to_max_int_when_not_using_emulator.approved.txt
+++ b/src/Tests/ApprovalFiles/MigrationTopologyTests.Should_set_MaxDeliveryCount_to_max_int_when_not_using_emulator.approved.txt
@@ -1,0 +1,25 @@
+CreateSubscriptionOptions: {
+  "LockDuration": "00:05:00",
+  "RequiresSession": false,
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "DeadLetteringOnMessageExpiration": false,
+  "EnableDeadLetteringOnFilterEvaluationExceptions": false,
+  "TopicName": "bundle-1",
+  "SubscriptionName": "MySub",
+  "MaxDeliveryCount": 2147483647,
+  "Status": {},
+  "ForwardTo": "SubscribingQueue",
+  "ForwardDeadLetteredMessagesTo": null,
+  "EnableBatchedOperations": true,
+  "UserMetadata": "SubscribingQueue"
+}
+CreateRuleOptions: {
+  "Filter": {
+    "filter-type": "false",
+    "SqlExpression": "1=0",
+    "Parameters": {}
+  },
+  "Action": null,
+  "Name": "$default"
+}

--- a/src/Tests/ApprovalFiles/QueueCreatorTests.Should_set_MaxDeliveryCount_to_10_when_using_emulator.approved.txt
+++ b/src/Tests/ApprovalFiles/QueueCreatorTests.Should_set_MaxDeliveryCount_to_10_when_using_emulator.approved.txt
@@ -1,0 +1,20 @@
+CreateQueueOptions: {
+  "Name": "test-queue",
+  "LockDuration": "00:05:00",
+  "MaxSizeInMegabytes": 5120,
+  "RequiresDuplicateDetection": false,
+  "RequiresSession": false,
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "DeadLetteringOnMessageExpiration": false,
+  "DuplicateDetectionHistoryTimeWindow": "00:01:00",
+  "MaxDeliveryCount": 10,
+  "EnableBatchedOperations": true,
+  "AuthorizationRules": [],
+  "Status": {},
+  "ForwardTo": null,
+  "ForwardDeadLetteredMessagesTo": null,
+  "EnablePartitioning": false,
+  "UserMetadata": null,
+  "MaxMessageSizeInKilobytes": null
+}

--- a/src/Tests/ApprovalFiles/QueueCreatorTests.Should_set_MaxDeliveryCount_to_max_int_when_not_using_emulator.approved.txt
+++ b/src/Tests/ApprovalFiles/QueueCreatorTests.Should_set_MaxDeliveryCount_to_max_int_when_not_using_emulator.approved.txt
@@ -1,0 +1,20 @@
+CreateQueueOptions: {
+  "Name": "test-queue",
+  "LockDuration": "00:05:00",
+  "MaxSizeInMegabytes": 5120,
+  "RequiresDuplicateDetection": false,
+  "RequiresSession": false,
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "DeadLetteringOnMessageExpiration": false,
+  "DuplicateDetectionHistoryTimeWindow": "00:01:00",
+  "MaxDeliveryCount": 2147483647,
+  "EnableBatchedOperations": true,
+  "AuthorizationRules": [],
+  "Status": {},
+  "ForwardTo": null,
+  "ForwardDeadLetteredMessagesTo": null,
+  "EnablePartitioning": false,
+  "UserMetadata": null,
+  "MaxMessageSizeInKilobytes": null
+}

--- a/src/Tests/ApprovalFiles/TopicPerEventTopologyTests.Should_set_MaxDeliveryCount_to_10_when_using_emulator.approved.txt
+++ b/src/Tests/ApprovalFiles/TopicPerEventTopologyTests.Should_set_MaxDeliveryCount_to_10_when_using_emulator.approved.txt
@@ -1,0 +1,40 @@
+CreateTopicOptions: {
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "MaxSizeInMegabytes": 5120,
+  "RequiresDuplicateDetection": false,
+  "DuplicateDetectionHistoryTimeWindow": "00:01:00",
+  "Name": "NServiceBus.Transport.AzureServiceBus.Tests.TopicPerEventTopologyTests\u002BMyEvent",
+  "AuthorizationRules": [],
+  "Status": {},
+  "EnablePartitioning": false,
+  "SupportOrdering": false,
+  "EnableBatchedOperations": true,
+  "UserMetadata": null,
+  "MaxMessageSizeInKilobytes": null
+}
+CreateSubscriptionOptions: {
+  "LockDuration": "00:05:00",
+  "RequiresSession": false,
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "DeadLetteringOnMessageExpiration": false,
+  "EnableDeadLetteringOnFilterEvaluationExceptions": false,
+  "TopicName": "NServiceBus.Transport.AzureServiceBus.Tests.TopicPerEventTopologyTests\u002BMyEvent",
+  "SubscriptionName": "SubscribingQueue",
+  "MaxDeliveryCount": 10,
+  "Status": {},
+  "ForwardTo": "SubscribingQueue",
+  "ForwardDeadLetteredMessagesTo": null,
+  "EnableBatchedOperations": true,
+  "UserMetadata": "SubscribingQueue"
+}
+CreateRuleOptions: {
+  "Filter": {
+    "filter-type": "true",
+    "SqlExpression": "1=1",
+    "Parameters": {}
+  },
+  "Action": null,
+  "Name": "$Default"
+}

--- a/src/Tests/ApprovalFiles/TopicPerEventTopologyTests.Should_set_MaxDeliveryCount_to_max_int_when_not_using_emulator.approved.txt
+++ b/src/Tests/ApprovalFiles/TopicPerEventTopologyTests.Should_set_MaxDeliveryCount_to_max_int_when_not_using_emulator.approved.txt
@@ -1,0 +1,40 @@
+CreateTopicOptions: {
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "MaxSizeInMegabytes": 5120,
+  "RequiresDuplicateDetection": false,
+  "DuplicateDetectionHistoryTimeWindow": "00:01:00",
+  "Name": "NServiceBus.Transport.AzureServiceBus.Tests.TopicPerEventTopologyTests\u002BMyEvent",
+  "AuthorizationRules": [],
+  "Status": {},
+  "EnablePartitioning": false,
+  "SupportOrdering": false,
+  "EnableBatchedOperations": true,
+  "UserMetadata": null,
+  "MaxMessageSizeInKilobytes": null
+}
+CreateSubscriptionOptions: {
+  "LockDuration": "00:05:00",
+  "RequiresSession": false,
+  "DefaultMessageTimeToLive": "10675199.02:48:05.4775807",
+  "AutoDeleteOnIdle": "10675199.02:48:05.4775807",
+  "DeadLetteringOnMessageExpiration": false,
+  "EnableDeadLetteringOnFilterEvaluationExceptions": false,
+  "TopicName": "NServiceBus.Transport.AzureServiceBus.Tests.TopicPerEventTopologyTests\u002BMyEvent",
+  "SubscriptionName": "SubscribingQueue",
+  "MaxDeliveryCount": 2147483647,
+  "Status": {},
+  "ForwardTo": "SubscribingQueue",
+  "ForwardDeadLetteredMessagesTo": null,
+  "EnableBatchedOperations": true,
+  "UserMetadata": "SubscribingQueue"
+}
+CreateRuleOptions: {
+  "Filter": {
+    "filter-type": "true",
+    "SqlExpression": "1=1",
+    "Parameters": {}
+  },
+  "Action": null,
+  "Name": "$Default"
+}

--- a/src/Tests/TransportConfigurationTests.cs
+++ b/src/Tests/TransportConfigurationTests.cs
@@ -7,6 +7,25 @@ using NUnit.Framework;
 public class TransportConfigurationTests
 {
     [Test]
+    [TestCase(
+        "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://192.168.1.1;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://192.168.1.1:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://servicebus-emulator;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://servicebus-emulator:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://host.docker.internal:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    public void InjectEmulatorAdminPort_should_append_port_5300_when_missing(string input, string expected) =>
+        Assert.That(AzureServiceBusTransport.InjectEmulatorAdminPort(input), Is.EqualTo(expected));
+
+    [Test]
     [TestCase(null)] // default
     [TestCase(0)] // no prefetch
     [TestCase(1)] // arbitrary

--- a/src/Transport/Administration/QueueCreator.cs
+++ b/src/Transport/Administration/QueueCreator.cs
@@ -20,7 +20,7 @@ class QueueCreator(AzureServiceBusTransport transportSettings)
             {
                 EnableBatchedOperations = true,
                 LockDuration = TimeSpan.FromMinutes(5),
-                MaxDeliveryCount = int.MaxValue,
+                MaxDeliveryCount = transportSettings.MaxDeliveryCount,
                 MaxSizeInMegabytes = transportSettings.EntityMaximumSizeInMegabytes,
                 EnablePartitioning = transportSettings.EnablePartitioning
             };

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -107,9 +107,12 @@ public partial class AzureServiceBusTransport : TransportDefinition
             ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, defaultClientOptions)
             : new ServiceBusClient(ConnectionString, defaultClientOptions);
 
+        var administrationConnectionString = IsUsingDevelopmentEmulator
+            ? InjectEmulatorAdminPort(ConnectionString!)
+            : ConnectionString!;
         var administrationClient = TokenCredential != null
             ? new ServiceBusAdministrationClient(FullyQualifiedNamespace, TokenCredential)
-            : new ServiceBusAdministrationClient(ConnectionString);
+            : new ServiceBusAdministrationClient(administrationConnectionString);
         var infrastructure = new AzureServiceBusTransportInfrastructure(this, hostSettings, receiveSettingsAndClientPairs, defaultClient, administrationClient, DestinationManager);
 
         if (hostSettings.SetupInfrastructure)
@@ -146,6 +149,21 @@ public partial class AzureServiceBusTransport : TransportDefinition
         }
 
         return infrastructure;
+    }
+
+    internal static string InjectEmulatorAdminPort(string connectionString)
+    {
+        // The Service Bus emulator requires port 5300 appended to the endpoint host for administration operations.
+        // If the connection string already contains a port in the endpoint, leave it as-is.
+        var properties = ServiceBusConnectionStringProperties.Parse(connectionString);
+        if (properties.Endpoint.Port != -1)
+        {
+            return connectionString;
+        }
+        return connectionString.Replace(
+            $"Endpoint=sb://{properties.Endpoint.Host};",
+            $"Endpoint=sb://{properties.Endpoint.Host}:5300;",
+            StringComparison.OrdinalIgnoreCase);
     }
 
     void ApplyRetryPolicyOptionsIfNeeded(ServiceBusClientOptions options)
@@ -383,6 +401,11 @@ public partial class AzureServiceBusTransport : TransportDefinition
     public OutgoingNativeMessageCustomizationAction? OutgoingNativeMessageCustomization { get; set; }
 
     internal string? ConnectionString { get; set; }
+
+    internal bool IsUsingDevelopmentEmulator =>
+        ConnectionString?.Contains("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase) ?? false;
+
+    internal int MaxDeliveryCount => IsUsingDevelopmentEmulator ? 10 : int.MaxValue;
 
     internal string? FullyQualifiedNamespace { get; set; }
     internal TokenCredential? TokenCredential { get; set; }

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -106,9 +106,10 @@ sealed class AzureServiceBusTransportInfrastructure : TransportInfrastructure
                     AdministrationClient = administrationClient,
                     Client = defaultClient,
                     EnablePartitioning = transportSettings.EnablePartitioning,
+                    EntityMaximumSizeInMegabytes = transportSettings.EntityMaximumSizeInMegabytes,
+                    MaxDeliveryCount = transportSettings.MaxDeliveryCount,
                     SetupInfrastructure = hostSettings.SetupInfrastructure,
-                    SubscribingQueueName = receiveAddress,
-                    EntityMaximumSizeInMegabytes = transportSettings.EntityMaximumSizeInMegabytes
+                    SubscribingQueueName = receiveAddress
                 }, hostSettings)
                 : null,
             subQueue

--- a/src/Transport/EventRouting/MigrationTopologyCreator.cs
+++ b/src/Transport/EventRouting/MigrationTopologyCreator.cs
@@ -67,7 +67,7 @@ sealed class MigrationTopologyCreator(AzureServiceBusTransport transportSettings
                         LockDuration = TimeSpan.FromMinutes(5),
                         ForwardTo = migrationTopology.TopicToSubscribeOn,
                         EnableDeadLetteringOnFilterEvaluationExceptions = false,
-                        MaxDeliveryCount = int.MaxValue,
+                        MaxDeliveryCount = transportSettings.MaxDeliveryCount,
                         EnableBatchedOperations = true,
                         UserMetadata = migrationTopology.TopicToSubscribeOn
                     };

--- a/src/Transport/EventRouting/MigrationTopologySubscriptionManager.cs
+++ b/src/Transport/EventRouting/MigrationTopologySubscriptionManager.cs
@@ -150,7 +150,7 @@ sealed class MigrationTopologySubscriptionManager : SubscriptionManager
             LockDuration = TimeSpan.FromMinutes(5),
             ForwardTo = CreationOptions.SubscribingQueueName,
             EnableDeadLetteringOnFilterEvaluationExceptions = false,
-            MaxDeliveryCount = int.MaxValue,
+            MaxDeliveryCount = CreationOptions.MaxDeliveryCount,
             EnableBatchedOperations = true,
             UserMetadata = CreationOptions.SubscribingQueueName
         };

--- a/src/Transport/EventRouting/SubscriptionManagerCreationOptions.cs
+++ b/src/Transport/EventRouting/SubscriptionManagerCreationOptions.cs
@@ -16,4 +16,6 @@ sealed class SubscriptionManagerCreationOptions
     public int EntityMaximumSizeInMegabytes { get; init; }
 
     public bool SetupInfrastructure { get; init; }
+
+    internal int MaxDeliveryCount { get; init; } = int.MaxValue;
 }

--- a/src/Transport/EventRouting/TopicPerEventTopologySubscriptionManager.cs
+++ b/src/Transport/EventRouting/TopicPerEventTopologySubscriptionManager.cs
@@ -127,7 +127,7 @@ sealed class TopicPerEventTopologySubscriptionManager : SubscriptionManager
                 LockDuration = TimeSpan.FromMinutes(5),
                 ForwardTo = creationOptions.SubscribingQueueName,
                 EnableDeadLetteringOnFilterEvaluationExceptions = false,
-                MaxDeliveryCount = int.MaxValue,
+                MaxDeliveryCount = creationOptions.MaxDeliveryCount,
                 EnableBatchedOperations = true,
                 UserMetadata = creationOptions.SubscribingQueueName
             };


### PR DESCRIPTION
This pull request is based on [this pull request](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1331) and allows NServiceBus to use the Azure Service Bus emulator to create queues, topics, and subscriptions. The emulator is still limited to 10 connections, as [detailed here](https://github.com/Azure/azure-service-bus-emulator-installer/issues/58#issuecomment-2984760245), but it now exposes the Azure Service Bus Management API to allow on-the-fly changes.

Related to #1104 