### PR TITLE
Support TestContainer connection strings for the Azure Service Bus emulator

### DIFF
--- a/src/Tests/TransportConfigurationTests.cs
+++ b/src/Tests/TransportConfigurationTests.cs
@@ -22,6 +22,21 @@ public class TransportConfigurationTests
     [TestCase(
         "Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
         "Endpoint=sb://host.docker.internal:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://localhost:5300/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://192.168.1.1/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://192.168.1.1:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://servicebus-emulator/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://servicebus-emulator:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
+    [TestCase(
+        "Endpoint=sb://host.docker.internal/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;",
+        "Endpoint=sb://host.docker.internal:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")]
     public void InjectEmulatorAdminPort_should_append_port_5300_when_missing(string input, string expected) =>
         Assert.That(AzureServiceBusTransport.InjectEmulatorAdminPort(input), Is.EqualTo(expected));
 

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -157,7 +157,15 @@ public partial class AzureServiceBusTransport : TransportDefinition
         // Currently, we have to also override any port already specified to workaround limitations in the transport
         // since we are not exposing the admin client we assume to always run on the default port with the emulator.
         var properties = ServiceBusConnectionStringProperties.Parse(connectionString);
-        return connectionString.Replace(properties.Endpoint.Port != -1 ? $"Endpoint=sb://{properties.Endpoint.Host}:{properties.Endpoint.Port};" : $"Endpoint=sb://{properties.Endpoint.Host};", $"Endpoint=sb://{properties.Endpoint.Host}:5300;", StringComparison.OrdinalIgnoreCase);
+        var endpoint = properties.Endpoint.Port != -1
+            ? $"Endpoint=sb://{properties.Endpoint.Host}:{properties.Endpoint.Port}"
+            : $"Endpoint=sb://{properties.Endpoint.Host}";
+        var replacement = $"Endpoint=sb://{properties.Endpoint.Host}:5300";
+        // UriBuilder.ToString() appends a trailing slash (e.g. sb://host:port/), so try that format first
+        var result = connectionString.Replace($"{endpoint}/;", $"{replacement};", StringComparison.OrdinalIgnoreCase);
+        return result != connectionString
+            ? result
+            : connectionString.Replace($"{endpoint};", $"{replacement};", StringComparison.OrdinalIgnoreCase);
     }
 
     void ApplyRetryPolicyOptionsIfNeeded(ServiceBusClientOptions options)


### PR DESCRIPTION
Backport of:
-  #1378

Which fixes for the `release-6.2` branch:
- #1375 