### PR TITLE
Throwing exception on publish to a missing topic

### DIFF
--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -20,7 +20,7 @@ namespace NServiceBus
         [System.Obsolete("The transport no longer supports sending the transport encoding header. Will be r" +
             "emoved in version 7.0.0.", true)]
         public bool SendTransportEncodingHeader { get; set; }
-        public bool ThrowOnMissingTopicWhenPublishing { get; init; }
+        public bool ThrowOnMissingTopicWhenPublishing { get; set; }
         public System.TimeSpan TimeToWaitBeforeTriggeringCircuitBreaker { get; set; }
         [System.Diagnostics.CodeAnalysis.MemberNotNull("topology")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNull("topology")]
@@ -42,6 +42,7 @@ namespace NServiceBus
         [System.Obsolete("The transport no longer supports sending the transport encoding header. Will be r" +
             "emoved in version 7.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> SendTransportEncodingHeader(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> ThrowOnMissingTopicWhenPublishing(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> TimeToWaitBeforeTriggeringCircuitBreaker(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.TimeSpan timeToWait) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> UseTransport<TTransport>(this NServiceBus.EndpointConfiguration endpointConfiguration, string connectionString, NServiceBus.TopicTopology topology)
             where TTransport : NServiceBus.AzureServiceBusTransport { }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -20,6 +20,7 @@ namespace NServiceBus
         [System.Obsolete("The transport no longer supports sending the transport encoding header. Will be r" +
             "emoved in version 7.0.0.", true)]
         public bool SendTransportEncodingHeader { get; set; }
+        public bool ThrowOnMissingTopicWhenPublishing { get; init; }
         public System.TimeSpan TimeToWaitBeforeTriggeringCircuitBreaker { get; set; }
         [System.Diagnostics.CodeAnalysis.MemberNotNull("topology")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNull("topology")]

--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -148,6 +148,43 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
             Assert.That(async () => await dispatcher.Dispatch(new TransportOperations(operation1, operation2), new TransportTransaction()), Throws.Nothing);
         }
 
+        // With pub sub the cases of the topic not being available are similar to having a topic without any subscribers
+        [Test]
+        public void Should_throw_when_multicast_dispatch_destination_not_available_and_throw_on_missing_topic_enabled()
+        {
+            var client = new FakeServiceBusClient();
+
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()
+            {
+                PublishedEventToTopicsMap = { { typeof(SomeEvent).FullName, "sometopic" } }
+            }), throwOnMissingTopic: true);
+
+            var sender = new FakeSender
+            {
+                SendMessageAction = _ => throw new ServiceBusException("Some exception", ServiceBusFailureReason.MessagingEntityNotFound),
+                SendMessageBatchAction = _ => throw new ServiceBusException("Some exception", ServiceBusFailureReason.MessagingEntityNotFound)
+            };
+            client.Senders["sometopic"] = sender;
+
+            var operation1 =
+                new TransportOperation(new OutgoingMessage("SomeId",
+                        [],
+                        ReadOnlyMemory<byte>.Empty),
+                    new MulticastAddressTag(typeof(SomeEvent)),
+                    [],
+                    DispatchConsistency.Isolated);
+
+            var operation2 =
+                new TransportOperation(new OutgoingMessage("SomeId",
+                        [],
+                        ReadOnlyMemory<byte>.Empty),
+                    new MulticastAddressTag(typeof(SomeEvent)),
+                    [],
+                    DispatchConsistency.Default);
+
+            Assert.That(async () => await dispatcher.Dispatch(new TransportOperations(operation1, operation2), new TransportTransaction()), Throws.InvalidOperationException);
+        }
+
         [Test]
         public async Task Should_dispatch_unicast_isolated_dispatches_individually_per_destination()
         {
@@ -744,7 +781,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
             var client = new FakeServiceBusClient();
             var destinationManager = GetDestinationManager("SomeHierarchyNamespace");
 
-            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()), destinationManager);
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()), destinationManager, throwOnMissingTopic: false);
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -802,7 +839,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                 {
                     PublishedEventToTopicsMap = { { typeof(SomeEvent).FullName, "sometopic" } }
                 }),
-                destinationManager);
+                destinationManager, throwOnMissingTopic: false);
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -857,7 +894,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                 options.ExcludeMessageType<ISomeCommandInterface>();
             });
 
-            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()), destinationManager);
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()), destinationManager, throwOnMissingTopic: false);
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",
@@ -922,7 +959,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                 {
                     PublishedEventToTopicsMap = { { typeof(SomeEvent).FullName, "sometopic" }, { typeof(SomeOtherEvent).FullName, "sometopic" }, { typeof(SomeImplementedEvent).FullName, "sometopic" } }
                 }),
-                destinationManager);
+                destinationManager, throwOnMissingTopic: false);
 
             var operation1 =
                 new TransportOperation(new OutgoingMessage("SomeId",

--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -698,6 +698,78 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
         }
 
         [Test]
+        public async Task Should_swallow_when_multicast_dispatch_sent_as_single_messages_destination_not_available()
+        {
+            var defaultClient = new FakeServiceBusClient();
+            var defaultSender = new FakeSender
+            {
+                SendMessageAction = _ => throw new ServiceBusException("Some exception", ServiceBusFailureReason.MessagingEntityNotFound),
+                SendMessageBatchAction = _ => throw new ServiceBusException("Some exception", ServiceBusFailureReason.MessagingEntityNotFound)
+            };
+            defaultClient.Senders[typeof(SomeEvent).FullName] = defaultSender;
+
+            defaultSender.TryAdd = msg => false;
+
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
+
+            var operations = new List<TransportOperation>(5);
+            for (int i = 0; i < 5; i++)
+            {
+                operations.Add(new TransportOperation(new OutgoingMessage($"SomeId{i}",
+                        new Dictionary<string, string> { { "Number", i.ToString() } },
+                        ReadOnlyMemory<byte>.Empty),
+                    new MulticastAddressTag(typeof(SomeEvent)),
+                    [],
+                    DispatchConsistency.Default));
+            }
+
+            var azureServiceBusTransaction = new AzureServiceBusTransportTransaction();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(async () => await dispatcher.Dispatch(new TransportOperations([.. operations]), azureServiceBusTransaction.TransportTransaction), Throws.Nothing);
+                Assert.That(defaultSender.BatchSentMessages, Has.Count.Zero);
+                Assert.That(defaultSender.IndividuallySentMessages, Has.Count.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public async Task Should_throw_when_multicast_dispatch_sent_as_single_messages_destination_not_available_and_throw_on_exception_set()
+        {
+            var defaultClient = new FakeServiceBusClient();
+            var defaultSender = new FakeSender
+            {
+                SendMessageAction = _ => throw new ServiceBusException("Some exception", ServiceBusFailureReason.MessagingEntityNotFound),
+                SendMessageBatchAction = _ => throw new ServiceBusException("Some exception", ServiceBusFailureReason.MessagingEntityNotFound)
+            };
+            defaultClient.Senders[typeof(SomeEvent).FullName] = defaultSender;
+
+            defaultSender.TryAdd = msg => false;
+
+            var dispatcher = new MessageDispatcher(defaultClient, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()), throwOnMissingTopic: true);
+
+            var operations = new List<TransportOperation>(5);
+            for (int i = 0; i < 5; i++)
+            {
+                operations.Add(new TransportOperation(new OutgoingMessage($"SomeId{i}",
+                        new Dictionary<string, string> { { "Number", i.ToString() } },
+                        ReadOnlyMemory<byte>.Empty),
+                    new MulticastAddressTag(typeof(SomeEvent)),
+                    [],
+                    DispatchConsistency.Default));
+            }
+
+            var azureServiceBusTransaction = new AzureServiceBusTransportTransaction();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(async () => await dispatcher.Dispatch(new TransportOperations([.. operations]), azureServiceBusTransaction.TransportTransaction), Throws.InvalidOperationException);
+                Assert.That(defaultSender.BatchSentMessages, Has.Count.Zero);
+                Assert.That(defaultSender.IndividuallySentMessages, Has.Count.EqualTo(0));
+            });
+        }
+
+        [Test]
         public async Task
             Should_fallback_to_individual_send_when_a_message_cannot_be_added_to_a_batch_but_batch_all_others()
         {

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -450,6 +450,11 @@ public partial class AzureServiceBusTransport : TransportDefinition
     /// </remarks>
     public OutgoingNativeMessageCustomizationAction? OutgoingNativeMessageCustomization { get; set; }
 
+    /// <summary>
+    /// Specifies whether to throw an exception when publishing to a non-existent topic
+    /// </summary>
+    public bool ThrowOnMissingTopicWhenPublishing { get; init; }
+
     internal string? ConnectionString { get; set; }
 
     internal bool IsUsingDevelopmentEmulator =>

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -453,7 +453,7 @@ public partial class AzureServiceBusTransport : TransportDefinition
     /// <summary>
     /// Specifies whether to throw an exception when publishing to a non-existent topic
     /// </summary>
-    public bool ThrowOnMissingTopicWhenPublishing { get; init; }
+    public bool ThrowOnMissingTopicWhenPublishing { get; set; }
 
     internal string? ConnectionString { get; set; }
 

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -44,6 +44,7 @@ sealed class AzureServiceBusTransportInfrastructure : TransportInfrastructure
             messageSenderRegistry,
             transportSettings.Topology,
             destinationManager,
+            transportSettings.ThrowOnMissingTopicWhenPublishing,
             transportSettings.OutgoingNativeMessageCustomization
         );
         Receivers = receiveSettingsAndClientPairs.ToDictionary(static settingsAndClient =>

--- a/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
@@ -168,4 +168,18 @@ public static partial class AzureServiceBusTransportSettingsExtensions
         transportExtensions.Transport.MaxAutoLockRenewalDuration = maximumAutoLockRenewalDuration;
         return transportExtensions;
     }
+
+    /// <summary>
+    /// Overrides the default transport behavior on message publishing and throws an <c>InvalidOperationException</c> if the destination topic doesn't exist
+    /// </summary>
+    /// <param name="transportExtensions"></param>
+    /// <exception cref="InvalidOperationException">When the destination topic doesn't exist</exception>
+    [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
+        Note = "Should not be converted to an ObsoleteEx until API mismatch described in issue is resolved.",
+        ReplacementTypeOrMember = "AzureServiceBusTransport.ThrowOnMissingTopicWhenPublishing")]
+    public static TransportExtensions<AzureServiceBusTransport> ThrowOnMissingTopicWhenPublishing(this TransportExtensions<AzureServiceBusTransport> transportExtensions)
+    {
+        transportExtensions.Transport.ThrowOnMissingTopicWhenPublishing = true;
+        return transportExtensions;
+    }
 }

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -234,12 +234,12 @@ class MessageDispatcher(
             {
                 if (Log.IsWarnEnabled)
                 {
-                    Log.Warn($"Skipping sending messages to topic {destination} because the destination does not exist.");
+                    Log.Warn($"Skipping publishing messages to topic {destination} because the destination does not exist.");
                 }
 
                 if (throwOnMissingTopic)
                 {
-                    throw new InvalidOperationException($"Sending messages to topic {destination} failed because the destination does not exist.", e);
+                    throw new InvalidOperationException($"Publishing messages to topic {destination} failed because the destination does not exist.", e);
                 }
 
                 return;
@@ -333,9 +333,14 @@ class MessageDispatcher(
         }
         catch (ServiceBusException e) when (isMulticast && e.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
         {
-            if (Log.IsDebugEnabled)
+            if (Log.IsWarnEnabled)
             {
-                Log.Debug($"Sending message with message ID '{message.MessageId}' to topic {destination} failed because the destination does not exist.");
+                Log.Warn($"Publishing message with message ID '{message.MessageId}' to topic {destination} failed because the destination does not exist.");
+            }
+
+            if (throwOnMissingTopic)
+            {
+                throw new InvalidOperationException($"Publishing message with message ID '{message.MessageId}' to topic {destination} failed because the destination does not exist.", e);
             }
         }
         catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -15,6 +15,7 @@ class MessageDispatcher(
     MessageSenderRegistry messageSenderRegistry,
     TopicTopology topology,
     DestinationManager destinationManager,
+    bool throwOnMissingTopic,
     OutgoingNativeMessageCustomizationAction? customizerCallback = null)
     : IMessageDispatcher
 {
@@ -30,7 +31,8 @@ class MessageDispatcher(
         ServiceBusClient defaultClient,
         MessageSenderRegistry messageSenderRegistry,
         TopicTopology topology,
-        OutgoingNativeMessageCustomizationAction? customizerCallback = null) : this(defaultClient, messageSenderRegistry, topology, new DestinationManager(HierarchyNamespaceOptions.None), customizerCallback)
+        bool throwOnMissingTopic = false,
+        OutgoingNativeMessageCustomizationAction? customizerCallback = null) : this(defaultClient, messageSenderRegistry, topology, new DestinationManager(HierarchyNamespaceOptions.None), throwOnMissingTopic, customizerCallback)
     {
     }
 
@@ -230,9 +232,14 @@ class MessageDispatcher(
             // when it tries to establish a link to a non-existing entity.
             catch (ServiceBusException e) when (isMulticast && e.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
             {
-                if (Log.IsDebugEnabled)
+                if (Log.IsWarnEnabled)
                 {
-                    Log.Debug($"Skipping sending messages to topic {destination} because the destination does not exist.");
+                    Log.Warn($"Skipping sending messages to topic {destination} because the destination does not exist.");
+                }
+
+                if (throwOnMissingTopic)
+                {
+                    throw new InvalidOperationException($"Sending messages to topic {destination} failed because the destination does not exist.", e);
                 }
 
                 return;


### PR DESCRIPTION
Fix https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/1255

This PR adds a new `ThrowOnMissingTopicWhenPublishing` transport configuration property, set to `false` by default for backward compatibility, that, when set to `true`, will cause the transport to throw an `InvalidOperationException` when publishing to a non-existent topic.

Alongside that, the message dispatcher now always logs a warning when publishing to a non-existent topic.