### PR TITLE
Allow configuring max delivery count

### DIFF
--- a/src/CommandLine/MigrationTopologyEndpoint.cs
+++ b/src/CommandLine/MigrationTopologyEndpoint.cs
@@ -8,11 +8,11 @@
 
     static class MigrationTopologyEndpoint
     {
-        public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption topicName, CommandOption topicToPublishTo, CommandOption topicToSubscribeOn, CommandOption subscriptionName, CommandOption<int> size, CommandOption partitioning, CommandOption hierarchyNamespace, CommandOption forwardDlqTo)
+        public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption topicName, CommandOption topicToPublishTo, CommandOption topicToSubscribeOn, CommandOption subscriptionName, CommandOption<int> size, CommandOption<int> deliveryCount, CommandOption partitioning, CommandOption hierarchyNamespace, CommandOption forwardDlqTo)
         {
             try
             {
-                await Queue.Create(client, name, size, partitioning, hierarchyNamespace, forwardDlqTo);
+                await Queue.Create(client, name, size, deliveryCount, partitioning, hierarchyNamespace, forwardDlqTo);
             }
             catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
             {

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -38,6 +38,11 @@
                 Description = "Queue size in GB (defaults to 5)"
             };
 
+            var deliveryCount = new CommandOption<int>(app.ValueParsers.GetParser<int>(), "-d|--delivery-count", CommandOptionType.SingleValue)
+            {
+                Description = "Maximum Delivery Count (defaults to int.MaxValue)"
+            };
+
             var partitioning = new CommandOption("-p|--partitioned", CommandOptionType.NoValue)
             {
                 Description = "Enable partitioning"
@@ -102,6 +107,7 @@
                     createCommand.AddOption(connectionString);
                     createCommand.AddOption(fullyQualifiedNamespace);
                     createCommand.AddOption(size);
+                    createCommand.AddOption(deliveryCount);
                     createCommand.AddOption(partitioning);
                     createCommand.AddOption(hierarchyNamespace);
 
@@ -110,7 +116,7 @@
                     createCommand.OnExecuteAsync(async ct =>
                     {
                         await CommandRunner.Run(connectionString, fullyQualifiedNamespace,
-                            client => TopicPerEventTopologyEndpoint.Create(client, name, size, partitioning, hierarchyNamespace, forwardDlqTo));
+                            client => TopicPerEventTopologyEndpoint.Create(client, name, size, deliveryCount, partitioning, hierarchyNamespace, forwardDlqTo));
 
                         Console.WriteLine($"Endpoint '{name.Value}' is ready.");
                     });
@@ -141,6 +147,7 @@
                         createCommand.AddOption(connectionString);
                         createCommand.AddOption(fullyQualifiedNamespace);
                         createCommand.AddOption(size);
+                        createCommand.AddOption(deliveryCount);
                         createCommand.AddOption(partitioning);
                         createCommand.AddOption(hierarchyNamespace);
                         var forwardDlqTo = CreateForwardDlqToOption(createCommand, name, hierarchyNamespace);
@@ -176,7 +183,7 @@
                             await CommandRunner.Run(connectionString, fullyQualifiedNamespace,
                                 client => MigrationTopologyEndpoint.Create(client, name, topicName,
                                     topicToPublishTo, topicToSubscribeOn,
-                                    subscriptionName, size, partitioning, hierarchyNamespace, forwardDlqTo));
+                                    subscriptionName, size, deliveryCount, partitioning, hierarchyNamespace, forwardDlqTo));
 
 
                             Console.WriteLine($"Endpoint '{name.Value}' is ready.");
@@ -270,6 +277,7 @@
                     createCommand.AddOption(connectionString);
                     createCommand.AddOption(fullyQualifiedNamespace);
                     createCommand.AddOption(size);
+                    createCommand.AddOption(deliveryCount);
                     createCommand.AddOption(partitioning);
                     createCommand.AddOption(hierarchyNamespace);
                     var forwardDlqTo = CreateForwardDlqToOption(createCommand, name, hierarchyNamespace);
@@ -278,7 +286,7 @@
                     {
                         try
                         {
-                            await CommandRunner.Run(connectionString, fullyQualifiedNamespace, client => Queue.Create(client, name, size, partitioning, hierarchyNamespace, forwardDlqTo));
+                            await CommandRunner.Run(connectionString, fullyQualifiedNamespace, client => Queue.Create(client, name, size, deliveryCount, partitioning, hierarchyNamespace, forwardDlqTo));
                             Console.WriteLine($"Queue name '{name.Value}', size '{(size.HasValue() ? size.ParsedValue : 5)}GB', partitioned '{partitioning.HasValue()}' created");
                         }
                         catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)

--- a/src/CommandLine/Queue.cs
+++ b/src/CommandLine/Queue.cs
@@ -8,7 +8,7 @@
 
     static class Queue
     {
-        public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption<int> size, CommandOption partitioning, CommandOption hierarchyNamespace, CommandOption forwardDeadLetteredMessagesTo)
+        public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption<int> size, CommandOption<int> deliverCount, CommandOption partitioning, CommandOption hierarchyNamespace, CommandOption forwardDeadLetteredMessagesTo)
         {
             var queueDescription = BuildDefaultCreateQueueOptions(name.ToHierarchyNamespaceAwareDestination(hierarchyNamespace));
 
@@ -33,7 +33,7 @@
             {
                 EnableBatchedOperations = true,
                 LockDuration = TimeSpan.FromMinutes(5),
-                MaxDeliveryCount = int.MaxValue,
+                MaxDeliveryCount = deliverCount.HasValue() ? deliverCount.ParsedValue : int.MaxValue,
                 MaxSizeInMegabytes = (size.HasValue() ? size.ParsedValue : 5) * 1024,
                 EnablePartitioning = partitioning.HasValue()
             };

--- a/src/CommandLine/TopicPerEventTopologyEndpoint.cs
+++ b/src/CommandLine/TopicPerEventTopologyEndpoint.cs
@@ -8,11 +8,11 @@ using McMaster.Extensions.CommandLineUtils;
 
 static class TopicPerEventTopologyEndpoint
 {
-    public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption<int> size, CommandOption partitioning, CommandOption hierarchyNamespace, CommandOption forwardDlqTo)
+    public static async Task Create(ServiceBusAdministrationClient client, CommandArgument name, CommandOption<int> size, CommandOption<int> deliveryCount, CommandOption partitioning, CommandOption hierarchyNamespace, CommandOption forwardDlqTo)
     {
         try
         {
-            await Queue.Create(client, name, size, partitioning, hierarchyNamespace, forwardDlqTo);
+            await Queue.Create(client, name, size, deliveryCount, partitioning, hierarchyNamespace, forwardDlqTo);
         }
         catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
         {

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -29,12 +29,12 @@
 
             var (output, error, exitCode) = await Execute($"endpoint create {EndpointName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName);
         }
@@ -47,12 +47,12 @@
 
             var (output, error, exitCode) = await Execute($"endpoint create {EndpointName} --hierarchy-namespace {HierarchyNamespace}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(queueName);
         }
@@ -65,12 +65,12 @@
 
             var (output, error, exitCode) = await Execute($"endpoint create {EndpointName} --forward-dlq-to {ErrorQueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName, forwardDeadLetteredMessagesTo: ErrorQueueName);
             await VerifyQueue(ErrorQueueName);
@@ -81,8 +81,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint create {EndpointName} --forward-dlq-to {EndpointName}");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The queue name and the --forward-dlq-to option cannot resolve to the same queue."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The queue name and the --forward-dlq-to option cannot resolve to the same queue."));
+            }
         }
 
         [Test]
@@ -90,8 +93,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint create {EndpointName} --hierarchy-namespace {HierarchyNamespace}/");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            }
         }
 
         [Test]
@@ -99,8 +105,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint create {EndpointName} --topic-to-publish-to {TopicName}");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("Unrecognized option '--topic-to-publish-to'"));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("Unrecognized option '--topic-to-publish-to'"));
+            }
         }
 
         [Test]
@@ -111,12 +120,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName);
             await VerifyTopic(DefaultTopicName);
@@ -133,12 +142,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --hierarchy-namespace {HierarchyNamespace}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(queueName);
             await VerifyTopic(topicName);
@@ -153,12 +162,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic {TopicName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName);
             await VerifyTopic(TopicName);
@@ -175,12 +184,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic {TopicName} --hierarchy-namespace {HierarchyNamespace}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(queueName);
             await VerifyTopic(topicName);
@@ -196,12 +205,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic {TopicName} --forward-dlq-to {ErrorQueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName, forwardDeadLetteredMessagesTo: ErrorQueueName);
             await VerifyQueue(ErrorQueueName);
@@ -223,12 +232,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic-to-publish-to {TopicName} --topic-to-subscribe-on {HierarchyTopicName} --hierarchy-namespace {HierarchyNamespace} --forward-dlq-to {ErrorQueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(queueName, forwardDeadLetteredMessagesTo: errorQueueName);
             await VerifyQueue(errorQueueName);
@@ -247,12 +256,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic-to-publish-to {TopicName} --topic-to-subscribe-on {HierarchyTopicName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName);
             await VerifyTopic(TopicName);
@@ -273,12 +282,12 @@
 
             var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic-to-publish-to {TopicName} --topic-to-subscribe-on {HierarchyTopicName} --hierarchy-namespace {HierarchyNamespace}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(queueName);
             await VerifyTopic(topicName);
@@ -292,8 +301,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint create {EndpointName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -301,8 +313,11 @@
         {
             var (_, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic {TopicName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -311,13 +326,17 @@
             var (_, publishError, publishExitCode) = await Execute($"migration endpoint create {EndpointName} --topic {TopicName} --topic-to-publish-to {HierarchyTopicName}");
             var (_, subscribeError, subscribeExitCode) = await Execute($"migration endpoint create {EndpointName} --topic {TopicName} --topic-to-subscribe-on {HierarchyTopicName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(publishExitCode, Is.EqualTo(1));
                 Assert.That(subscribeExitCode, Is.EqualTo(1));
-            });
-            Assert.That(publishError, Does.Contain("The --topic option and the --topic-to-publish-to option cannot be combined. Choose either a single topic name by specifying the --topic option or a hierarchy by specifying both the --topic-to-publish-to option, and --topic-to-subscribe-on option."));
-            Assert.That(subscribeError, Does.Contain("The --topic option and the--topic-to-subscribe-on option cannot be combined. Choose either a single topic name by specifying the --topic option or a hierarchy by specifying both the --topic-to-publish-to option, and --topic-to-subscribe-on option."));
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(publishError, Does.Contain("The --topic option and the --topic-to-publish-to option cannot be combined. Choose either a single topic name by specifying the --topic option or a hierarchy by specifying both the --topic-to-publish-to option, and --topic-to-subscribe-on option."));
+                Assert.That(subscribeError, Does.Contain("The --topic option and the--topic-to-subscribe-on option cannot be combined. Choose either a single topic name by specifying the --topic option or a hierarchy by specifying both the --topic-to-publish-to option, and --topic-to-subscribe-on option."));
+            }
         }
 
         [Test]
@@ -325,8 +344,11 @@
         {
             var (_, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic-to-subscribe-on {HierarchyTopicName} --topic-to-publish-to {HierarchyTopicName}");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("A valid topic hierarchy requires the topic-to-publish-to option and the topic-to-subscribe-on option to be different."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("A valid topic hierarchy requires the topic-to-publish-to option and the topic-to-subscribe-on option to be different."));
+            }
         }
 
         [Test]
@@ -449,8 +471,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint subscribe {EndpointName} MyMessage1 --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -458,8 +483,11 @@
         {
             var (_, error, exitCode) = await Execute($"migration endpoint subscribe {EndpointName} MyMessage1 --topic {TopicName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -467,8 +495,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint subscribe {EndpointName} MyMessage1 --hierarchy-namespace {HierarchyNamespace}/");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            }
         }
 
         [Test]
@@ -595,8 +626,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint unsubscribe {EndpointName} MyMessage1 --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -604,8 +638,11 @@
         {
             var (_, error, exitCode) = await Execute($"migration endpoint unsubscribe {EndpointName} MyMessage1 --topic {TopicName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -613,8 +650,11 @@
         {
             var (_, error, exitCode) = await Execute($"endpoint unsubscribe {EndpointName} MyMessage1 --hierarchy-namespace {HierarchyNamespace}/");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            }
         }
 
         [Test]
@@ -624,12 +664,12 @@
 
             var (output, error, exitCode) = await Execute($"queue create {QueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName);
         }
@@ -642,12 +682,12 @@
 
             var (output, error, exitCode) = await Execute($"queue create {QueueName} --hierarchy-namespace {HierarchyNamespace}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(queueName);
         }
@@ -660,12 +700,12 @@
 
             var (output, error, exitCode) = await Execute($"queue create {QueueName} --forward-dlq-to {ErrorQueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(QueueName, forwardDeadLetteredMessagesTo: ErrorQueueName);
             await VerifyQueue(ErrorQueueName);
@@ -681,12 +721,12 @@
 
             var (output, error, exitCode) = await Execute($"queue create {QueueName} --hierarchy-namespace {HierarchyNamespace} --forward-dlq-to {ErrorQueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output, Does.Not.Contain("skipping"));
-            });
+            }
 
             await VerifyQueue(queueName, forwardDeadLetteredMessagesTo: errorQueueName);
             await VerifyQueue(errorQueueName);
@@ -697,8 +737,11 @@
         {
             var (_, error, exitCode) = await Execute($"queue create {QueueName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -706,8 +749,11 @@
         {
             var (_, error, exitCode) = await Execute($"queue create {QueueName} --hierarchy-namespace {HierarchyNamespace}/");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            }
         }
 
         [Test]
@@ -715,8 +761,11 @@
         {
             var (_, error, exitCode) = await Execute($"queue create {QueueName} --forward-dlq-to {QueueName}");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The queue name and the --forward-dlq-to option cannot resolve to the same queue."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The queue name and the --forward-dlq-to option cannot resolve to the same queue."));
+            }
         }
 
         [Test]
@@ -727,12 +776,12 @@
 
             var (output, error, exitCode) = await Execute($"queue create {QueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output.Contains("skipping"), Is.True);
-            });
+            }
 
             await VerifyQueue(QueueName);
         }
@@ -746,12 +795,12 @@
 
             var (output, error, exitCode) = await Execute($"queue create {QueueName} --hierarchy-namespace {HierarchyNamespace}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
                 Assert.That(output.Contains("skipping"), Is.True);
-            });
+            }
 
             await VerifyQueue(queueName);
         }
@@ -764,11 +813,11 @@
 
             var (_, error, exitCode) = await Execute($"queue delete {QueueName}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
-            });
+            }
 
             await VerifyQueueExists(false);
         }
@@ -782,11 +831,11 @@
 
             var (_, error, exitCode) = await Execute($"queue delete {QueueName} --hierarchy-namespace {HierarchyNamespace}");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(exitCode, Is.Zero);
                 Assert.That(error, Is.Empty);
-            });
+            }
 
             await VerifyQueueExists(false, queueName);
         }
@@ -796,8 +845,11 @@
         {
             var (_, error, exitCode) = await Execute($"queue delete {QueueName} --namespace somenamespace.servicebus.windows.net --connection-string someConnectionString");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The connection string and the namespace option cannot be used together."));
+            }
         }
 
         [Test]
@@ -805,27 +857,30 @@
         {
             var (_, error, exitCode) = await Execute($"queue delete {QueueName} --hierarchy-namespace {HierarchyNamespace}/");
 
-            Assert.That(exitCode, Is.EqualTo(1));
-            Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(error, Does.Contain("The hierarchy namespace cannot end with a '/' character."));
+            }
         }
 
         [SetUp]
         public void Setup()
             => client = new ServiceBusAdministrationClient(Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString"));
 
-        async Task VerifyQueue(string queueName, bool enablePartitioning = false, int size = 5 * 1024, string forwardDeadLetteredMessagesTo = null)
+        async Task VerifyQueue(string queueName, bool enablePartitioning = false, int size = 5 * 1024, int maxDeliveryCount = int.MaxValue, string forwardDeadLetteredMessagesTo = null)
         {
             var actual = (await client.GetQueueAsync(queueName)).Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.That(actual.MaxDeliveryCount, Is.EqualTo(int.MaxValue));
+                Assert.That(actual.MaxDeliveryCount, Is.EqualTo(maxDeliveryCount));
                 Assert.That(actual.LockDuration, Is.EqualTo(TimeSpan.FromMinutes(5)));
-                Assert.That(actual.EnableBatchedOperations, Is.EqualTo(true));
+                Assert.That(actual.EnableBatchedOperations, Is.True);
                 Assert.That(actual.EnablePartitioning, Is.EqualTo(enablePartitioning));
                 Assert.That(actual.MaxSizeInMegabytes, Is.EqualTo(size));
                 AssertDlqForwardingDestination(actual.ForwardDeadLetteredMessagesTo, forwardDeadLetteredMessagesTo);
-            });
+            }
         }
 
         static void AssertDlqForwardingDestination(string actualForwardingDestination, string expectedForwardingDestination)
@@ -846,19 +901,19 @@
         {
             var actual = (await client.GetTopicAsync(topicName)).Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(actual.EnableBatchedOperations, Is.EqualTo(true));
                 Assert.That(actual.EnablePartitioning, Is.EqualTo(enablePartitioning));
                 Assert.That(actual.MaxSizeInMegabytes, Is.EqualTo(size));
-            });
+            }
         }
 
         async Task VerifyTopicPerEventTypeSubscription(string topicName, string subscriptionName, string queueName)
         {
             var actual = (await client.GetSubscriptionAsync(topicName, subscriptionName)).Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(actual.LockDuration, Is.EqualTo(TimeSpan.FromMinutes(5)));
                 Assert.That(actual.ForwardTo.EndsWith($"/{queueName}", StringComparison.Ordinal), Is.True);
@@ -866,7 +921,7 @@
                 Assert.That(actual.MaxDeliveryCount, Is.EqualTo(int.MaxValue));
                 Assert.That(actual.EnableBatchedOperations, Is.EqualTo(true));
                 Assert.That(actual.UserMetadata, Is.EqualTo(queueName));
-            });
+            }
         }
 
         async Task VerifySubscriptionDoesNotExist(string topicName, string subscriptionName)
@@ -879,7 +934,7 @@
         {
             var actual = (await client.GetSubscriptionAsync(topicName, subscriptionName)).Value;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(actual.LockDuration, Is.EqualTo(TimeSpan.FromMinutes(5)));
                 Assert.That(actual.ForwardTo.EndsWith($"/{queueName}", StringComparison.Ordinal), Is.True);
@@ -887,7 +942,7 @@
                 Assert.That(actual.MaxDeliveryCount, Is.EqualTo(int.MaxValue));
                 Assert.That(actual.EnableBatchedOperations, Is.EqualTo(true));
                 Assert.That(actual.UserMetadata, Is.EqualTo(queueName));
-            });
+            }
 
             // rules
             var rules = new List<RuleProperties>();
@@ -900,32 +955,32 @@
             Assert.That(rules, Has.Count.EqualTo(4));
 
             var defaultRule = rules[0];
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(defaultRule.Name, Is.EqualTo("$default"));
                 Assert.That(((FalseRuleFilter)defaultRule.Filter).SqlExpression, Is.EqualTo(new FalseRuleFilter().SqlExpression));
-            });
+            }
 
             var customRuleNameRule = rules[1];
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(customRuleNameRule.Name, Is.EqualTo("CustomRuleName"));
                 Assert.That(((SqlRuleFilter)customRuleNameRule.Filter).SqlExpression, Is.EqualTo(new SqlRuleFilter("[NServiceBus.EnclosedMessageTypes] LIKE '%MyNamespace1.MyMessage3%'").SqlExpression));
-            });
+            }
 
             var myMessage1Rule = rules[2];
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(myMessage1Rule.Name, Is.EqualTo("MyMessage1"));
                 Assert.That(((SqlRuleFilter)myMessage1Rule.Filter).SqlExpression, Is.EqualTo(new SqlRuleFilter("[NServiceBus.EnclosedMessageTypes] LIKE '%MyMessage1%'").SqlExpression));
-            });
+            }
 
             var myMessage2WithNamespace = rules[3];
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(myMessage2WithNamespace.Name, Is.EqualTo("MyNamespace1.MyMessage2"));
                 Assert.That(((SqlRuleFilter)myMessage2WithNamespace.Filter).SqlExpression, Is.EqualTo(new SqlRuleFilter("[NServiceBus.EnclosedMessageTypes] LIKE '%MyNamespace1.MyMessage2%'").SqlExpression));
-            });
+            }
         }
 
         async Task VerifySubscriptionContainsOnlyDefaultRejectAllRule(string topicName, string subscriptionName)
@@ -940,11 +995,11 @@
             Assert.That(rules, Has.Count.EqualTo(1));
 
             var defaultRule = rules[0];
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(defaultRule.Name, Is.EqualTo("$default"));
                 Assert.That(((FalseRuleFilter)defaultRule.Filter).SqlExpression, Is.EqualTo(new FalseRuleFilter().SqlExpression));
-            });
+            }
         }
 
         async Task VerifySubscriptionContainsOnlyDefaultMatchAllRule(string topicName, string subscriptionName)
@@ -959,11 +1014,11 @@
             Assert.That(rules, Has.Count.EqualTo(1));
 
             var defaultRule = rules[0];
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(defaultRule.Name, Is.EqualTo("$default"));
                 Assert.That(((TrueRuleFilter)defaultRule.Filter).SqlExpression, Is.EqualTo(new TrueRuleFilter().SqlExpression));
-            });
+            }
         }
 
         async Task VerifyQueueExists(bool queueShouldExist, string queueName = QueueName)

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -77,6 +77,23 @@
         }
 
         [Test]
+        public async Task Create_endpoint_with_delivery_count()
+        {
+            await DeleteQueue(QueueName);
+
+            var (output, error, exitCode) = await Execute($"endpoint create {EndpointName} --delivery-count {15}");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.Zero);
+                Assert.That(error, Is.Empty);
+                Assert.That(output, Does.Not.Contain("skipping"));
+            }
+
+            await VerifyQueue(QueueName, maxDeliveryCount: 15);
+        }
+
+        [Test]
         public async Task Create_endpoint_with_dlq_forwarding_validates_target_is_not_self()
         {
             var (_, error, exitCode) = await Execute($"endpoint create {EndpointName} --forward-dlq-to {EndpointName}");
@@ -216,6 +233,24 @@
             await VerifyQueue(ErrorQueueName);
             await VerifyTopic(TopicName);
             await VerifySubscriptionContainsOnlyDefaultRejectAllRule(TopicName, SubscriptionName);
+        }
+
+        [Test]
+        public async Task Create_migration_with_delivery_count()
+        {
+            await DeleteQueue(QueueName);
+            await DeleteTopic(TopicName);
+
+            var (output, error, exitCode) = await Execute($"migration endpoint create {EndpointName} --topic {TopicName} --delivery-count {15}");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.Zero);
+                Assert.That(error, Is.Empty);
+                Assert.That(output, Does.Not.Contain("skipping"));
+            }
+
+            await VerifyQueue(QueueName, maxDeliveryCount: 15);
         }
 
         [Test]
@@ -672,6 +707,23 @@
             }
 
             await VerifyQueue(QueueName);
+        }
+
+        [Test]
+        public async Task Create_queue_with_delivery_count()
+        {
+            await DeleteQueue(QueueName);
+
+            var (output, error, exitCode) = await Execute($"queue create {QueueName} --delivery-count {15}");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(exitCode, Is.Zero);
+                Assert.That(error, Is.Empty);
+                Assert.That(output, Does.Not.Contain("skipping"));
+            }
+
+            await VerifyQueue(QueueName, maxDeliveryCount: 15);
         }
 
         [Test]

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -8,7 +8,7 @@ namespace NServiceBus
         public AzureServiceBusTransport(string connectionString, NServiceBus.TopicTopology topology) { }
         public AzureServiceBusTransport(string fullyQualifiedNamespace, Azure.Core.TokenCredential tokenCredential, NServiceBus.TopicTopology topology) { }
         public System.TimeSpan? AutoDeleteOnIdle { get; set; }
-        public bool AutoForwardDeadLetteredMessagesToErrorQueue { get; set; }
+        public bool? AutoForwardDeadLetteredMessagesToErrorQueue { get; set; }
         public bool EnablePartitioning { get; set; }
         public int EntityMaximumSize { get; set; }
         public NServiceBus.Transport.AzureServiceBus.HierarchyNamespaceOptions HierarchyNamespaceOptions { get; set; }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -13,6 +13,7 @@ namespace NServiceBus
         public int EntityMaximumSize { get; set; }
         public NServiceBus.Transport.AzureServiceBus.HierarchyNamespaceOptions HierarchyNamespaceOptions { get; set; }
         public System.TimeSpan? MaxAutoLockRenewalDuration { get; set; }
+        public int MaxDeliveryCount { get; set; }
         public System.Action<NServiceBus.Transport.IOutgoingTransportOperation, Azure.Messaging.ServiceBus.ServiceBusMessage>? OutgoingNativeMessageCustomization { get; set; }
         public int? PrefetchCount { get; set; }
         public int PrefetchMultiplier { get; set; }
@@ -41,6 +42,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> EntityMaximumSize(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int maximumSizeInGB) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> HierarchyNamespaceOptions(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, NServiceBus.Transport.AzureServiceBus.HierarchyNamespaceOptions hierarchyNamespaceOptions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> MaxAutoLockRenewalDuration(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, System.TimeSpan maximumAutoLockRenewalDuration) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> MaxDeliveryCount(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int maxDeliveryCount) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> PrefetchCount(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int prefetchCount) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> PrefetchMultiplier(this NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> transportExtensions, int prefetchMultiplier) { }
         [System.Obsolete("The transport no longer supports sending the transport encoding header. Will be r" +

--- a/src/Tests/ApprovalFiles/TransportSettingsConventionTests.Transport_properties_have_PreObsolete_extension_method_mappings.approved.txt
+++ b/src/Tests/ApprovalFiles/TransportSettingsConventionTests.Transport_properties_have_PreObsolete_extension_method_mappings.approved.txt
@@ -5,6 +5,7 @@ Mapped properties:
   - EntityMaximumSize
   - HierarchyNamespaceOptions
   - MaxAutoLockRenewalDuration
+  - MaxDeliveryCount
   - OutgoingNativeMessageCustomization
   - PrefetchCount
   - PrefetchMultiplier

--- a/src/Tests/Receiving/MessagePumpTests.cs
+++ b/src/Tests/Receiving/MessagePumpTests.cs
@@ -2,10 +2,13 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
+    using NServiceBus.Logging;
+    using NServiceBus.Testing;
     using NUnit.Framework;
 
     [TestFixture]
@@ -318,6 +321,87 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Receiving
                 Assert.That(fakeReceiver.CompletedMessages, Is.Empty);
                 Assert.That(fakeReceiver.AbandonedMessages, Is.Empty);
             });
+        }
+
+        [Test]
+        public async Task Should_warn_when_dead_lettering_and_AutoForwardDeadLetteredMessagesToErrorQueue_is_not_set()
+        {
+            var logOutput = new StringWriter();
+            using var logScope = LogManager.Use<TestingLoggerFactory>().BeginScope(logOutput, LogLevel.Warn);
+
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport("connection-string", TopicTopology.Default), "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            await pump.Initialize(new PushRuntimeSettings(1), (_, _) => Task.FromException<InvalidOperationException>(new InvalidOperationException("boom")),
+                (context, _) =>
+                {
+                    context.TransportTransaction.Set(new DeadLetterRequest("Some reason", "Some description"));
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                }, CancellationToken.None);
+            await pump.StartReceive();
+
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+            await fakeClient.Processors["receiveAddress"].ProcessMessage(receivedMessage, fakeReceiver);
+
+            var logText = logOutput.ToString();
+            Assert.That(logText, Does.Contain("AutoForwardDeadLetteredMessagesToErrorQueue"));
+        }
+
+        [Test]
+        public async Task Should_not_warn_when_dead_lettering_and_AutoForwardDeadLetteredMessagesToErrorQueue_is_false()
+        {
+            var logOutput = new StringWriter();
+            using var logScope = LogManager.Use<TestingLoggerFactory>().BeginScope(logOutput, LogLevel.Warn);
+
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport("connection-string", TopicTopology.Default) { AutoForwardDeadLetteredMessagesToErrorQueue = false }, "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            await pump.Initialize(new PushRuntimeSettings(1), (_, _) => Task.FromException<InvalidOperationException>(new InvalidOperationException("boom")),
+                (context, _) =>
+                {
+                    context.TransportTransaction.Set(new DeadLetterRequest("Some reason", "Some description"));
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                }, CancellationToken.None);
+            await pump.StartReceive();
+
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+            await fakeClient.Processors["receiveAddress"].ProcessMessage(receivedMessage, fakeReceiver);
+
+            var logText = logOutput.ToString();
+            Assert.That(logText, Does.Not.Contain("AutoForwardDeadLetteredMessagesToErrorQueue"));
+        }
+
+        [Test]
+        public async Task Should_not_warn_when_dead_lettering_and_AutoForwardDeadLetteredMessagesToErrorQueue_is_true()
+        {
+            var logOutput = new StringWriter();
+            using var logScope = LogManager.Use<TestingLoggerFactory>().BeginScope(logOutput, LogLevel.Warn);
+
+            var fakeClient = new FakeServiceBusClient();
+            var fakeReceiver = new FakeReceiver();
+
+            var pump = new MessagePump(fakeClient, new AzureServiceBusTransport("connection-string", TopicTopology.Default) { AutoForwardDeadLetteredMessagesToErrorQueue = true }, "receiveAddress",
+                new ReceiveSettings("TestReceiver", new QueueAddress("receiveAddress"), false, false, "error"), (s, exception, arg3) => { }, null);
+
+            await pump.Initialize(new PushRuntimeSettings(1), (_, _) => Task.FromException<InvalidOperationException>(new InvalidOperationException("boom")),
+                (context, _) =>
+                {
+                    context.TransportTransaction.Set(new DeadLetterRequest("Some reason", "Some description"));
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                }, CancellationToken.None);
+            await pump.StartReceive();
+
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(messageId: "SomeId", lockedUntil: DateTimeOffset.UtcNow.AddSeconds(60));
+            await fakeClient.Processors["receiveAddress"].ProcessMessage(receivedMessage, fakeReceiver);
+
+            var logText = logOutput.ToString();
+            Assert.That(logText, Does.Not.Contain("AutoForwardDeadLetteredMessagesToErrorQueue"));
         }
     }
 }

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -107,7 +107,7 @@ public partial class AzureServiceBusTransport : TransportDefinition
             ? new ServiceBusClient(FullyQualifiedNamespace, TokenCredential, defaultClientOptions)
             : new ServiceBusClient(ConnectionString, defaultClientOptions);
 
-        var administrationConnectionString = IsUsingDevelopmentEmulator
+        var administrationConnectionString = IsUsingDevelopmentEmulator(ConnectionString)
             ? InjectEmulatorAdminPort(ConnectionString!)
             : ConnectionString!;
         var administrationClient = TokenCredential != null
@@ -187,7 +187,7 @@ public partial class AzureServiceBusTransport : TransportDefinition
             // and core might allow different error queues in the future so we will not make any assumptions here
             var errorQueueName = DestinationManager.GetDestination(receiver.ErrorQueue);
 
-            // Core always adds the error queue as a "sending address" so it's likely already added hence the TryAdd 
+            // Core always adds the error queue as a "sending address" so it's likely already added hence the TryAdd
             queuesToCreate.TryAdd(errorQueueName, BuildDefaultCreateQueueOptions(errorQueueName));
 
             var receiveQueueName = AzureServiceBusTransportInfrastructure.ToTransportAddress(receiver.ReceiveAddress, DestinationManager);
@@ -293,7 +293,7 @@ public partial class AzureServiceBusTransport : TransportDefinition
     /// <summary>
     /// Gets or sets the maximum time period that a queue can remain idle before Azure Service Bus automatically deletes it.
     /// </summary>
-    /// <value>The idle timeout after which unused entities are automatically deleted. The minimum allowed value is 5 minutes.</value>    
+    /// <value>The idle timeout after which unused entities are automatically deleted. The minimum allowed value is 5 minutes.</value>
     /// <remarks>
     /// <para>
     /// This property controls the AutoDeleteOnIdle setting for queues created by the transport.
@@ -303,7 +303,7 @@ public partial class AzureServiceBusTransport : TransportDefinition
     /// </para>
     /// <para>
     /// This setting only applies to queues, not to topics or subscriptions. Topics and subscriptions are considered
-    /// shared infrastructure and are not affected by this property. Only instance-specific input queues (such when using 'MakeInstanceUniquelyAddressable') 
+    /// shared infrastructure and are not affected by this property. Only instance-specific input queues (such when using 'MakeInstanceUniquelyAddressable')
     /// will have AutoDeleteOnIdle applied, while shared queues (such as error and audit queues) remain unaffected to prevent unintended deletion of critical infrastructure.
     /// </para>
     /// <para>
@@ -436,6 +436,28 @@ public partial class AzureServiceBusTransport : TransportDefinition
     }
 
     /// <summary>
+    /// Set the maximum delivery count that is applied to queues that are created when the infrastructure is setup
+    /// </summary>
+    /// <remarks>This MaxDeliveryCount is set to <value>int.Max</value> by default, to stay backward compatible will change in the
+    /// next major version to a lower default value. When the emulator is used the value defaults to <value>10</value>
+    /// unless explicitly set to another value.</remarks>
+    public int MaxDeliveryCount
+    {
+        get;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, nameof(MaxDeliveryCount));
+
+            field = value;
+        }
+    } = int.MaxValue;
+
+    /// <summary>
+    /// Specifies whether to throw an exception when publishing to a non-existent topic
+    /// </summary>
+    public bool ThrowOnMissingTopicWhenPublishing { get; set; }
+
+    /// <summary>
     /// Gets or sets the action that allows customization of the native <see cref="ServiceBusMessage"/>
     /// just before it is dispatched to the Azure Service Bus SDK client.
     /// </summary>
@@ -450,17 +472,21 @@ public partial class AzureServiceBusTransport : TransportDefinition
     /// </remarks>
     public OutgoingNativeMessageCustomizationAction? OutgoingNativeMessageCustomization { get; set; }
 
-    /// <summary>
-    /// Specifies whether to throw an exception when publishing to a non-existent topic
-    /// </summary>
-    public bool ThrowOnMissingTopicWhenPublishing { get; set; }
+    internal string? ConnectionString
+    {
+        get;
+        set
+        {
+            if (IsUsingDevelopmentEmulator(value))
+            {
+                MaxDeliveryCount = 10;
+            }
 
-    internal string? ConnectionString { get; set; }
+            field = value;
+        }
+    }
 
-    internal bool IsUsingDevelopmentEmulator =>
-        ConnectionString?.Contains("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase) ?? false;
-
-    internal int MaxDeliveryCount => IsUsingDevelopmentEmulator ? 10 : int.MaxValue;
+    static bool IsUsingDevelopmentEmulator(string? connectionString) => connectionString?.Contains("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase) ?? false;
 
     internal string? FullyQualifiedNamespace { get; set; }
     internal TokenCredential? TokenCredential { get; set; }

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus;
+namespace NServiceBus;
 
 using System;
 using System.Collections.Generic;
@@ -440,7 +440,14 @@ public partial class AzureServiceBusTransport : TransportDefinition
     /// </summary>
     /// <remarks>This MaxDeliveryCount is set to <value>int.Max</value> by default, to stay backward compatible will change in the
     /// next major version to a lower default value. When the emulator is used the value defaults to <value>10</value>
-    /// unless explicitly set to another value.</remarks>
+    /// unless explicitly set to another value.
+    /// <para>
+    /// NServiceBus recoverability controls retry decisions via the recoverability policy, so this value should be high enough
+    /// to allow the recoverability policy to eventually move the message to the error queue. It should also not be set so high
+    /// that it effectively becomes infinite retries. To use the native dead letter queue instead of the error queue,
+    /// enable <see cref="AutoForwardDeadLetteredMessagesToErrorQueue"/>.
+    /// </para>
+    /// </remarks>
     public int MaxDeliveryCount
     {
         get;

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -436,11 +436,15 @@ public partial class AzureServiceBusTransport : TransportDefinition
     }
 
     /// <summary>
-    /// Set the maximum delivery count that is applied to queues that are created when the infrastructure is setup
+    /// Set the maximum delivery count that is applied to queues that are created when the infrastructure is setup.
     /// </summary>
-    /// <remarks>This MaxDeliveryCount is set to <value>int.Max</value> by default, to stay backward compatible will change in the
-    /// next major version to a lower default value. When the emulator is used the value defaults to <value>10</value>
+    /// <remarks>
+    /// <para>
+    /// This MaxDeliveryCount is set to <value>int.MaxValue</value> by default, to stay backward compatible. the
+    /// This value will change to a lower default value in the next major version. 
+    /// When the emulator is used the value defaults to <value>10</value>
     /// unless explicitly set to another value.
+    /// </para>
     /// <para>
     /// NServiceBus recoverability controls retry decisions via the recoverability policy, so this value should be high enough
     /// to allow the recoverability policy to eventually move the message to the error queue. It should also not be set so high

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -200,7 +200,7 @@ public partial class AzureServiceBusTransport : TransportDefinition
                 receiveQueue.AutoDeleteOnIdle = AutoDeleteOnIdle.Value;
             }
 
-            if (AutoForwardDeadLetteredMessagesToErrorQueue)
+            if (AutoForwardDeadLetteredMessagesToErrorQueue == true)
             {
                 receiveQueue.ForwardDeadLetteredMessagesTo = errorQueueName;
             }
@@ -332,13 +332,27 @@ public partial class AzureServiceBusTransport : TransportDefinition
     public bool EnablePartitioning { get; set; }
 
     /// <summary>
-    /// Enables auto-forwarding of dead-lettered messages to the configured error queue.
+    /// Controls whether dead-lettered messages are automatically forwarded to the configured error queue.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// When set to <see langword="true"/>, the transport configures the queue's <c>ForwardDeadLetteredMessagesTo</c> property so that
+    /// Azure Service Bus automatically forwards any dead-lettered message to the error queue.
+    /// </para>
+    /// <para>
+    /// When set to <see langword="null"/> (the default), the transport logs a warning whenever a message is dead-lettered,
+    /// recommending that this setting be enabled to ensure dead-lettered messages are visible in the error queue.
+    /// </para>
+    /// <para>
+    /// When set to <see langword="false"/>, dead-lettered messages remain in the Azure Service Bus dead-letter queue and no warning is logged.
+    /// Use this value to explicitly opt out of both forwarding and the associated warning.
+    /// </para>
+    /// <para>
     /// This option only affects queues created by the transport during infrastructure setup. It applies to transport-created endpoint queues,
     /// including instance-specific queues, and excludes the error queue itself to avoid self-forwarding loops.
+    /// </para>
     /// </remarks>
-    public bool AutoForwardDeadLetteredMessagesToErrorQueue { get; set; }
+    public bool? AutoForwardDeadLetteredMessagesToErrorQueue { get; set; }
 
     /// <summary>
     /// Specifies the multiplier to apply to the maximum concurrency value to calculate the prefetch count.

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -446,10 +446,15 @@ public partial class AzureServiceBusTransport : TransportDefinition
     /// unless explicitly set to another value.
     /// </para>
     /// <para>
-    /// NServiceBus recoverability controls retry decisions via the recoverability policy, so this value should be high enough
-    /// to allow the recoverability policy to eventually move the message to the error queue. It should also not be set so high
-    /// that it effectively becomes infinite retries. To use the native dead letter queue instead of the error queue,
-    /// enable <see cref="AutoForwardDeadLetteredMessagesToErrorQueue"/>.
+    /// NServiceBus recoverability controls retry decisions via the recoverability policy. This value should be high enough
+    /// to allow all configured retries to complete, so that the recoverability policy can eventually move the message to the error queue.
+    /// It should not be set so high that it effectively becomes infinite retries.
+    /// </para>
+    /// <para>
+    /// When lowering this value below the total number of recoverability retries allowed, the broker will dead-letter
+    /// the message before the recoverability policy can move it to the error queue. Enabling
+    /// <see cref="AutoForwardDeadLetteredMessagesToErrorQueue"/> ensures those messages are forwarded to the error queue,
+    /// making failures visible in ServiceControl.
     /// </para>
     /// </remarks>
     public int MaxDeliveryCount

--- a/src/Transport/AzureServiceBusTransportInfrastructure.cs
+++ b/src/Transport/AzureServiceBusTransportInfrastructure.cs
@@ -74,7 +74,7 @@ sealed class AzureServiceBusTransportInfrastructure : TransportInfrastructure
             CustomTokenProvider = transportSettings.TokenCredential?.ToString() ?? "default",
             CustomRetryPolicy = transportSettings.RetryPolicyOptions?.ToString() ?? "default",
             AutoDeleteOnIdle = transportSettings.AutoDeleteOnIdle?.ToString() ?? "default",
-            AutoForwardDeadLetteredMessagesToErrorQueue = transportSettings.AutoForwardDeadLetteredMessagesToErrorQueue.ToString(),
+            AutoForwardDeadLetteredMessagesToErrorQueue = transportSettings.AutoForwardDeadLetteredMessagesToErrorQueue?.ToString() ?? "not set",
         });
 
     void WriteManifest(StartupDiagnosticEntries startupDiagnostic)

--- a/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
@@ -159,6 +159,19 @@ public static partial class AzureServiceBusTransportSettingsExtensions
     /// </summary>
     /// <param name="transportExtensions"></param>
     /// <param name="maxDeliveryCount">The maximum delivery count to use.</param>
+    /// <remarks>
+    /// <para>
+    /// NServiceBus recoverability controls retry decisions via the recoverability policy. This value should be high enough
+    /// to allow all configured retries to complete, so that the recoverability policy can eventually move the message to the error queue.
+    /// It should not be set so high that it effectively becomes infinite retries.
+    /// </para>
+    /// <para>
+    /// When lowering this value below the total number of recoverability retries allowed, the broker will dead-letter
+    /// the message before the recoverability policy can move it to the error queue. Enabling
+    /// <see cref="AzureServiceBusTransport.AutoForwardDeadLetteredMessagesToErrorQueue"/> ensures those messages are forwarded to the error queue,
+    /// making failures visible in ServiceControl.
+    /// </para>
+    /// </remarks>
     [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
         Note = "Should not be converted to an ObsoleteEx until API mismatch described in the issue is resolved.",
         ReplacementTypeOrMember = "AzureServiceBusTransport.MaxDeliveryCount")]

--- a/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
@@ -155,6 +155,20 @@ public static partial class AzureServiceBusTransportSettingsExtensions
     }
 
     /// <summary>
+    /// Overrides the maximum delivery count with the specified value.
+    /// </summary>
+    /// <param name="transportExtensions"></param>
+    /// <param name="maxDeliveryCount">The maximum delivery count to use.</param>
+    [PreObsolete("https://github.com/Particular/NServiceBus/issues/6811",
+        Note = "Should not be converted to an ObsoleteEx until API mismatch described in the issue is resolved.",
+        ReplacementTypeOrMember = "AzureServiceBusTransport.MaxDeliveryCount")]
+    public static TransportExtensions<AzureServiceBusTransport> MaxDeliveryCount(this TransportExtensions<AzureServiceBusTransport> transportExtensions, int maxDeliveryCount)
+    {
+        transportExtensions.Transport.MaxDeliveryCount = maxDeliveryCount;
+        return transportExtensions;
+    }
+
+    /// <summary>
     /// Overrides the default time to wait before triggering a circuit breaker that initiates the endpoint shutdown procedure when the message pump cannot successfully receive a message.
     /// </summary>
     /// <param name="transportExtensions"></param>

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -32,7 +32,9 @@ sealed class MessagePump(
     CancellationTokenSource? messageProcessingCancellationTokenSource;
     ServiceBusProcessor? processor;
 
-    static readonly ILog Logger = LogManager.GetLogger<MessagePump>();
+    readonly ILog Logger = LogManager.GetLogger<MessagePump>();
+
+    bool autoForwardWarningLogged;
 
     PushRuntimeSettings? limitations;
 
@@ -140,6 +142,7 @@ sealed class MessagePump(
         catch (Exception ex)
         {
             Logger.Error($"Moving message '{nativeMessageId}' to the dead letter queue", ex);
+            WarnIfDeadLetteringWithoutForwarding(nativeMessageId, message.DeliveryCount);
             await arg.SafeDeadLetterMessage(message, nativeMessageId, TransactionMode, new DeadLetterRequest(ex), CancellationToken.None).ConfigureAwait(false);
 
             return;
@@ -295,6 +298,7 @@ sealed class MessagePump(
                     case ErrorHandleResult.Handled:
                         if (azureServiceBusTransaction.TransportTransaction.TryGet<DeadLetterRequest>(out var deadLetterRequest))
                         {
+                            WarnIfDeadLetteringWithoutForwarding(nativeMessageId, message.DeliveryCount);
                             await processMessageEventArgs.SafeDeadLetterMessage(message,
                                     nativeMessageId,
                                     TransactionMode,
@@ -352,6 +356,19 @@ sealed class MessagePump(
                     Timeout = TransactionManager.DefaultTimeout
                 })
             : new AzureServiceBusTransportTransaction();
+
+    void WarnIfDeadLetteringWithoutForwarding(string nativeMessageId, int deliveryCount)
+    {
+        if (!autoForwardWarningLogged && transportSettings.AutoForwardDeadLetteredMessagesToErrorQueue == null)
+        {
+            autoForwardWarningLogged = true;
+            Logger.Warn($"Message '{nativeMessageId}' (delivery count: {deliveryCount}) is being moved to the dead-letter queue. " +
+                "Dead-lettered messages will not automatically appear in the error queue. " +
+                "Consider setting 'AutoForwardDeadLetteredMessagesToErrorQueue = true' on the transport to automatically forward dead-lettered messages to the error queue, " +
+                "making them visible for monitoring and reprocessing. " +
+                "To suppress this warning, explicitly set 'AutoForwardDeadLetteredMessagesToErrorQueue = false'.");
+        }
+    }
 
     public ISubscriptionManager? Subscriptions { get; } = subscriptionManager;
 

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -359,7 +359,7 @@ sealed class MessagePump(
 
     void WarnIfDeadLetteringWithoutForwarding(string nativeMessageId, int deliveryCount)
     {
-        if (Interlocked.CompareExchange(ref autoForwardWarningLogged, 1, 0) != 0 || transportSettings.AutoForwardDeadLetteredMessagesToErrorQueue != null)
+        if (transportSettings.AutoForwardDeadLetteredMessagesToErrorQueue != null || Interlocked.CompareExchange(ref autoForwardWarningLogged, 1, 0) != 0)
         {
             return;
         }

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -34,7 +34,7 @@ sealed class MessagePump(
 
     readonly ILog Logger = LogManager.GetLogger<MessagePump>();
 
-    bool autoForwardWarningLogged;
+    int autoForwardWarningLogged;
 
     PushRuntimeSettings? limitations;
 
@@ -359,15 +359,16 @@ sealed class MessagePump(
 
     void WarnIfDeadLetteringWithoutForwarding(string nativeMessageId, int deliveryCount)
     {
-        if (!autoForwardWarningLogged && transportSettings.AutoForwardDeadLetteredMessagesToErrorQueue == null)
+        if (Interlocked.CompareExchange(ref autoForwardWarningLogged, 1, 0) != 0 || transportSettings.AutoForwardDeadLetteredMessagesToErrorQueue != null)
         {
-            autoForwardWarningLogged = true;
-            Logger.Warn($"Message '{nativeMessageId}' (delivery count: {deliveryCount}) is being moved to the dead-letter queue. " +
-                "Dead-lettered messages will not automatically appear in the error queue. " +
-                "Consider setting 'AutoForwardDeadLetteredMessagesToErrorQueue = true' on the transport to automatically forward dead-lettered messages to the error queue, " +
-                "making them visible for monitoring and reprocessing. " +
-                "To suppress this warning, explicitly set 'AutoForwardDeadLetteredMessagesToErrorQueue = false'.");
+            return;
         }
+
+        Logger.Warn($"Message '{nativeMessageId}' (delivery count: {deliveryCount}) is being moved to the dead-letter queue. " +
+                    "Dead-lettered messages will not automatically appear in the error queue. " +
+                    "Consider setting 'AutoForwardDeadLetteredMessagesToErrorQueue = true' on the transport to automatically forward dead-lettered messages to the error queue, " +
+                    "making them visible for monitoring and reprocessing. Other messages moved to the dead-letter queue will not be logged to avoid flooding the logs." +
+                    "To suppress this warning, explicitly set 'AutoForwardDeadLetteredMessagesToErrorQueue = false'.");
     }
 
     public ISubscriptionManager? Subscriptions { get; } = subscriptionManager;


### PR DESCRIPTION
This change exposes the `MaxDeliveryCount` setting directly on `AzureServiceBusTransport`, giving users explicit control over the maximum delivery count applied to queues created during endpoint infrastructure setup.

## Rationale

Previously, the transport used `int.MaxValue` as the hard-coded default for `MaxDeliveryCount`, which effectively disabled Azure Service Bus's built-in delivery count limits and deferred all retry decisions to NServiceBus recoverability. While this maintains backward compatibility, it prevents users from surfacing Azure Service Bus's native retry behavior and from tuning delivery count independently of recoverability policy.

By exposing `MaxDeliveryCount`, we:
- Make the setting explicit and discoverable in code-based configuration.
- Provide a path to change the default to a saner value in the next major version. The current default remains `int.MaxValue` to avoid breaking existing deployments.
- Allow the Azure Service Bus Emulator (which requires a value of `10`) to receive a sensible default automatically, while still permitting users to override it.

## Usage

```csharp
var transport = new AzureServiceBusTransport(connectionString, TopicTopology.Default)
{
    MaxDeliveryCount = 15
};
```

## Recommendations

When choosing a value, consider the interaction with NServiceBus recoverability:
- The value should be **high enough** to allow the configured recoverability policy to eventually move the message to the error queue.
- It should **not be so high** that it effectively creates infinite retries.
- If you prefer Azure Service Bus's native dead-letter queue over NServiceBus's error queue, enable `AutoForwardDeadLetteredMessagesToErrorQueue`.