### PR TITLE
Adjust how DLQ properties are upconverted to fault headers

### DIFF
--- a/src/AcceptanceTests/When_dlq_forwarding_is_enabled.cs
+++ b/src/AcceptanceTests/When_dlq_forwarding_is_enabled.cs
@@ -43,8 +43,8 @@ public class When_dlq_forwarding_is_enabled : NServiceBusAcceptanceTest
             Assert.That(nativeMessage.DeadLetterSource, Is.EqualTo(sourceEndpoint.ToLower()), "Message should have come via the dlq of the processing endpoint");
             Assert.That(nativeMessage.ApplicationProperties["SomeProperty"], Is.EqualTo("Some value"), "Message properties should have been set");
             Assert.That(failedMessageHeaders[FaultsHeaderKeys.FailedQ], Is.EqualTo(nativeMessage.DeadLetterSource), $"{FaultsHeaderKeys.FailedQ} should be set to dlq source");
-            Assert.That(failedMessageHeaders[FaultsHeaderKeys.Message], Is.EqualTo("Some reason"), $"{FaultsHeaderKeys.Message} should be set from dlq reason");
-            Assert.That(failedMessageHeaders[FaultsHeaderKeys.StackTrace], Is.EqualTo("Some description"), $"{FaultsHeaderKeys.StackTrace} should be set to dlq description");
+            Assert.That(failedMessageHeaders[FaultsHeaderKeys.ExceptionType], Is.EqualTo("Some reason"), $"{FaultsHeaderKeys.ExceptionType} should be set from dlq reason");
+            Assert.That(failedMessageHeaders[FaultsHeaderKeys.Message], Is.EqualTo("Some description"), $"{FaultsHeaderKeys.Message} should be set to dlq description");
         });
     }
 

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -83,7 +83,7 @@ namespace NServiceBus.Testing
 }
 namespace NServiceBus.Transport.AzureServiceBus.AdvancedExtensibility
 {
-    public static class MessageExtensions
+    public static class ServiceBusReceivedMessageExtensions
     {
         extension(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message)
         {

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -81,6 +81,15 @@ namespace NServiceBus.Testing
         public static System.Action<Azure.Messaging.ServiceBus.ServiceBusMessage>? GetNativeMessageCustomization(this NServiceBus.Extensibility.ExtendableOptions options) { }
     }
 }
+namespace NServiceBus.Transport.AzureServiceBus.AdvancedExtensibility
+{
+    public static class MessageExtensions
+    {
+        public static System.BinaryData GetBody(this Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message) { }
+        public static string GetMessageId(this Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message) { }
+        public static System.Collections.Generic.Dictionary<string, string?> GetNServiceBusHeaders(this Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message) { }
+    }
+}
 namespace NServiceBus.Transport.AzureServiceBus
 {
     [System.AttributeUsage(System.AttributeTargets.Property)]

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -85,9 +85,12 @@ namespace NServiceBus.Transport.AzureServiceBus.AdvancedExtensibility
 {
     public static class MessageExtensions
     {
-        public static System.BinaryData GetBody(this Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message) { }
-        public static string GetMessageId(this Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message) { }
-        public static System.Collections.Generic.Dictionary<string, string?> GetNServiceBusHeaders(this Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message) { }
+        extension(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message)
+        {
+            public System.Collections.Generic.Dictionary<string, string?> GetNServiceBusHeaders() { }
+            public string GetMessageId() { }
+            public System.BinaryData GetBody() { }
+        }
     }
 }
 namespace NServiceBus.Transport.AzureServiceBus

--- a/src/Tests/ApprovalFiles/TransportSettingsConventionTests.Transport_properties_have_PreObsolete_extension_method_mappings.approved.txt
+++ b/src/Tests/ApprovalFiles/TransportSettingsConventionTests.Transport_properties_have_PreObsolete_extension_method_mappings.approved.txt
@@ -9,6 +9,7 @@ Mapped properties:
   - PrefetchCount
   - PrefetchMultiplier
   - RetryPolicyOptions
+  - ThrowOnMissingTopicWhenPublishing
   - TimeToWaitBeforeTriggeringCircuitBreaker
   - UseWebSockets
 

--- a/src/Tests/Receiving/MessageExtensionsTests.cs
+++ b/src/Tests/Receiving/MessageExtensionsTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using AdvancedExtensibility;
     using Azure.Messaging.ServiceBus;
     using NServiceBus.Transport.AzureServiceBus.Configuration;
     using NUnit.Framework;

--- a/src/Tests/Receiving/ServiceBusReceivedMessageExtensionsTests.cs
+++ b/src/Tests/Receiving/ServiceBusReceivedMessageExtensionsTests.cs
@@ -8,7 +8,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class MessageExtensionsTests
+    public class ServiceBusReceivedMessageExtensionsTests
     {
         [Test]
         public void Should_extract_headers()

--- a/src/Transport/Receiving/MessageExtensions.cs
+++ b/src/Transport/Receiving/MessageExtensions.cs
@@ -16,6 +16,10 @@ public static class MessageExtensions
     /// <summary>
     /// Extracts NServiceBus headers from the <see cref="ServiceBusReceivedMessage"/>
     /// </summary>
+    /// <remarks>
+    /// In addition to converting all application properties to headers native message properties like ReplyTo, ContentType are also exposed as properties.
+    /// For dead lettered messages source, reason and description is mapped to relevant NServiceBus fault headers for better integration with the platform.
+    /// </remarks>
     public static Dictionary<string, string?> GetNServiceBusHeaders(this ServiceBusReceivedMessage message)
     {
         var headers = new Dictionary<string, string?>(message.ApplicationProperties.Count);
@@ -63,6 +67,10 @@ public static class MessageExtensions
     /// <summary>
     /// Returns the message ID for the <see cref="ServiceBusReceivedMessage"/>.
     /// </summary>
+    /// <remarks>
+    /// If no native message ID is present (testing indicates that the service always assigns one) the NServiceBus message ID will be used.
+    /// If none of these are present a deterministic GUID based in the EnqueuedTime and SequenceNumber is used to ensure an ID is always returned.
+    /// </remarks>
     public static string GetMessageId(this ServiceBusReceivedMessage message)
     {
         if (!string.IsNullOrWhiteSpace(message.MessageId))
@@ -81,6 +89,10 @@ public static class MessageExtensions
     /// <summary>
     /// Returns the message body of the <see cref="ServiceBusReceivedMessage"/>.
     /// </summary>
+    /// <remarks>
+    /// If the NServiceBus.Transport.Encoding application property indicates that the message originates from a legacy endpoint, (wcf/byte-array),
+    /// the body is deserialized using a XmlDictionaryReader for backwards compatibility.
+    /// </remarks>
     public static BinaryData GetBody(this ServiceBusReceivedMessage message)
     {
         var body = message.Body ?? new BinaryData([]);

--- a/src/Transport/Receiving/MessageExtensions.cs
+++ b/src/Transport/Receiving/MessageExtensions.cs
@@ -13,101 +13,104 @@ using Faults;
 /// </summary>
 public static class MessageExtensions
 {
-    /// <summary>
-    /// Extracts NServiceBus headers from the <see cref="ServiceBusReceivedMessage"/>
-    /// </summary>
-    /// <remarks>
-    /// In addition to converting all application properties to headers native message properties like ReplyTo, ContentType are also exposed as properties.
-    /// For dead lettered messages source, reason and description is mapped to relevant NServiceBus fault headers for better integration with the platform.
-    /// </remarks>
-    public static Dictionary<string, string?> GetNServiceBusHeaders(this ServiceBusReceivedMessage message)
+    extension(ServiceBusReceivedMessage message)
     {
-        var headers = new Dictionary<string, string?>(message.ApplicationProperties.Count);
-
-        foreach (var kvp in message.ApplicationProperties)
+        /// <summary>
+        /// Extracts NServiceBus headers from the <see cref="ServiceBusReceivedMessage"/>
+        /// </summary>
+        /// <remarks>
+        /// In addition to converting all application properties to headers native message properties like ReplyTo, ContentType are also exposed as properties.
+        /// For dead lettered messages source, reason and description is mapped to relevant NServiceBus fault headers for better integration with the platform.
+        /// </remarks>
+        public Dictionary<string, string?> GetNServiceBusHeaders()
         {
-            headers[kvp.Key] = kvp.Value?.ToString();
+            var headers = new Dictionary<string, string?>(message.ApplicationProperties.Count);
+
+            foreach (var kvp in message.ApplicationProperties)
+            {
+                headers[kvp.Key] = kvp.Value?.ToString();
+            }
+
+            headers.Remove(TransportMessageHeaders.TransportEncoding);
+
+            if (!string.IsNullOrWhiteSpace(message.ReplyTo))
+            {
+                headers[Headers.ReplyToAddress] = message.ReplyTo;
+            }
+
+            if (!string.IsNullOrWhiteSpace(message.CorrelationId))
+            {
+                headers[Headers.CorrelationId] = message.CorrelationId;
+            }
+
+            if (!string.IsNullOrWhiteSpace(message.ContentType))
+            {
+                headers[Headers.ContentType] = message.ContentType;
+            }
+
+            if (!headers.ContainsKey(FaultsHeaderKeys.FailedQ) && !string.IsNullOrWhiteSpace(message.DeadLetterSource))
+            {
+                headers[FaultsHeaderKeys.FailedQ] = message.DeadLetterSource;
+            }
+
+            if (!headers.ContainsKey(FaultsHeaderKeys.Message) && !string.IsNullOrWhiteSpace(message.DeadLetterReason))
+            {
+                headers[FaultsHeaderKeys.ExceptionType] = message.DeadLetterReason;
+            }
+
+            if (!headers.ContainsKey(FaultsHeaderKeys.StackTrace) && !string.IsNullOrWhiteSpace(message.DeadLetterErrorDescription))
+            {
+                headers[FaultsHeaderKeys.Message] = message.DeadLetterErrorDescription;
+            }
+
+            return headers;
         }
 
-        headers.Remove(TransportMessageHeaders.TransportEncoding);
-
-        if (!string.IsNullOrWhiteSpace(message.ReplyTo))
+        /// <summary>
+        /// Returns the message ID for the <see cref="ServiceBusReceivedMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// If no native message ID is present (testing indicates that the service always assigns one) the NServiceBus message ID will be used.
+        /// If none of these are present a deterministic GUID based in the EnqueuedTime and SequenceNumber is used to ensure an ID is always returned.
+        /// </remarks>
+        public string GetMessageId()
         {
-            headers[Headers.ReplyToAddress] = message.ReplyTo;
+            if (!string.IsNullOrWhiteSpace(message.MessageId))
+            {
+                return message.MessageId;
+            }
+
+            if (message.ApplicationProperties.TryGetValue(Headers.MessageId, out var id) && id?.ToString() is { } messageId && !string.IsNullOrWhiteSpace(messageId))
+            {
+                return messageId;
+            }
+
+            return GuidHelper.CreateVersion8(message.EnqueuedTime, message.SequenceNumber).ToString();
         }
 
-        if (!string.IsNullOrWhiteSpace(message.CorrelationId))
+        /// <summary>
+        /// Returns the message body of the <see cref="ServiceBusReceivedMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the NServiceBus.Transport.Encoding application property indicates that the message originates from a legacy endpoint, (wcf/byte-array),
+        /// the body is deserialized using a XmlDictionaryReader for backwards compatibility.
+        /// </remarks>
+        public BinaryData GetBody()
         {
-            headers[Headers.CorrelationId] = message.CorrelationId;
+            var body = message.Body ?? new BinaryData([]);
+            var memory = body.ToMemory();
+
+            if (memory.IsEmpty ||
+                !message.ApplicationProperties.TryGetValue(TransportMessageHeaders.TransportEncoding, out var value) ||
+                !value.Equals("wcf/byte-array"))
+            {
+                return body;
+            }
+
+            using var reader = XmlDictionaryReader.CreateBinaryReader(body.ToStream(), XmlDictionaryReaderQuotas.Max);
+            var bodyBytes = (byte[])Deserializer.ReadObject(reader)!;
+            return new BinaryData(bodyBytes);
         }
-
-        if (!string.IsNullOrWhiteSpace(message.ContentType))
-        {
-            headers[Headers.ContentType] = message.ContentType;
-        }
-
-        if (!headers.ContainsKey(FaultsHeaderKeys.FailedQ) && !string.IsNullOrWhiteSpace(message.DeadLetterSource))
-        {
-            headers[FaultsHeaderKeys.FailedQ] = message.DeadLetterSource;
-        }
-
-        if (!headers.ContainsKey(FaultsHeaderKeys.Message) && !string.IsNullOrWhiteSpace(message.DeadLetterReason))
-        {
-            headers[FaultsHeaderKeys.ExceptionType] = message.DeadLetterReason;
-        }
-
-        if (!headers.ContainsKey(FaultsHeaderKeys.StackTrace) && !string.IsNullOrWhiteSpace(message.DeadLetterErrorDescription))
-        {
-            headers[FaultsHeaderKeys.Message] = message.DeadLetterErrorDescription;
-        }
-
-        return headers;
-    }
-
-    /// <summary>
-    /// Returns the message ID for the <see cref="ServiceBusReceivedMessage"/>.
-    /// </summary>
-    /// <remarks>
-    /// If no native message ID is present (testing indicates that the service always assigns one) the NServiceBus message ID will be used.
-    /// If none of these are present a deterministic GUID based in the EnqueuedTime and SequenceNumber is used to ensure an ID is always returned.
-    /// </remarks>
-    public static string GetMessageId(this ServiceBusReceivedMessage message)
-    {
-        if (!string.IsNullOrWhiteSpace(message.MessageId))
-        {
-            return message.MessageId;
-        }
-
-        if (message.ApplicationProperties.TryGetValue(Headers.MessageId, out var id) && id?.ToString() is { } messageId && !string.IsNullOrWhiteSpace(messageId))
-        {
-            return messageId;
-        }
-
-        return GuidHelper.CreateVersion8(message.EnqueuedTime, message.SequenceNumber).ToString();
-    }
-
-    /// <summary>
-    /// Returns the message body of the <see cref="ServiceBusReceivedMessage"/>.
-    /// </summary>
-    /// <remarks>
-    /// If the NServiceBus.Transport.Encoding application property indicates that the message originates from a legacy endpoint, (wcf/byte-array),
-    /// the body is deserialized using a XmlDictionaryReader for backwards compatibility.
-    /// </remarks>
-    public static BinaryData GetBody(this ServiceBusReceivedMessage message)
-    {
-        var body = message.Body ?? new BinaryData([]);
-        var memory = body.ToMemory();
-
-        if (memory.IsEmpty ||
-            !message.ApplicationProperties.TryGetValue(TransportMessageHeaders.TransportEncoding, out var value) ||
-            !value.Equals("wcf/byte-array"))
-        {
-            return body;
-        }
-
-        using var reader = XmlDictionaryReader.CreateBinaryReader(body.ToStream(), XmlDictionaryReaderQuotas.Max);
-        var bodyBytes = (byte[])Deserializer.ReadObject(reader)!;
-        return new BinaryData(bodyBytes);
     }
 
     static readonly DataContractSerializer Deserializer = new(typeof(byte[]));

--- a/src/Transport/Receiving/MessageExtensions.cs
+++ b/src/Transport/Receiving/MessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.AzureServiceBus;
+﻿namespace NServiceBus.Transport.AzureServiceBus.AdvancedExtensibility;
 
 using System;
 using System.Collections.Generic;
@@ -8,8 +8,14 @@ using Azure.Messaging.ServiceBus;
 using Configuration;
 using Faults;
 
-static class MessageExtensions
+/// <summary>
+/// Helpers to get ID, headers and body for the message being processed. Intentionally public to enable reuse in the functions package.
+/// </summary>
+public static class MessageExtensions
 {
+    /// <summary>
+    /// Extracts NServiceBus headers from the <see cref="ServiceBusReceivedMessage"/>
+    /// </summary>
     public static Dictionary<string, string?> GetNServiceBusHeaders(this ServiceBusReceivedMessage message)
     {
         var headers = new Dictionary<string, string?>(message.ApplicationProperties.Count);
@@ -43,17 +49,20 @@ static class MessageExtensions
 
         if (!headers.ContainsKey(FaultsHeaderKeys.Message) && !string.IsNullOrWhiteSpace(message.DeadLetterReason))
         {
-            headers[FaultsHeaderKeys.Message] = message.DeadLetterReason;
+            headers[FaultsHeaderKeys.ExceptionType] = message.DeadLetterReason;
         }
 
         if (!headers.ContainsKey(FaultsHeaderKeys.StackTrace) && !string.IsNullOrWhiteSpace(message.DeadLetterErrorDescription))
         {
-            headers[FaultsHeaderKeys.StackTrace] = message.DeadLetterErrorDescription;
+            headers[FaultsHeaderKeys.Message] = message.DeadLetterErrorDescription;
         }
 
         return headers;
     }
 
+    /// <summary>
+    /// Returns the message ID for the <see cref="ServiceBusReceivedMessage"/>.
+    /// </summary>
     public static string GetMessageId(this ServiceBusReceivedMessage message)
     {
         if (!string.IsNullOrWhiteSpace(message.MessageId))
@@ -69,6 +78,9 @@ static class MessageExtensions
         return GuidHelper.CreateVersion8(message.EnqueuedTime, message.SequenceNumber).ToString();
     }
 
+    /// <summary>
+    /// Returns the message body of the <see cref="ServiceBusReceivedMessage"/>.
+    /// </summary>
     public static BinaryData GetBody(this ServiceBusReceivedMessage message)
     {
         var body = message.Body ?? new BinaryData([]);

--- a/src/Transport/Receiving/MessagePump.cs
+++ b/src/Transport/Receiving/MessagePump.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using AdvancedExtensibility;
 using Azure.Messaging.ServiceBus;
 using BitFaster.Caching.Lru;
 using Extensibility;

--- a/src/Transport/Receiving/ServiceBusReceivedMessageExtensions.cs
+++ b/src/Transport/Receiving/ServiceBusReceivedMessageExtensions.cs
@@ -11,7 +11,7 @@ using Faults;
 /// <summary>
 /// Helpers to get ID, headers and body for the message being processed. Intentionally public to enable reuse in the functions package.
 /// </summary>
-public static class MessageExtensions
+public static class ServiceBusReceivedMessageExtensions
 {
     extension(ServiceBusReceivedMessage message)
     {

--- a/src/Transport/Receiving/ServiceBusReceivedMessageExtensions.cs
+++ b/src/Transport/Receiving/ServiceBusReceivedMessageExtensions.cs
@@ -108,10 +108,14 @@ public static class ServiceBusReceivedMessageExtensions
             }
 
             using var reader = XmlDictionaryReader.CreateBinaryReader(body.ToStream(), XmlDictionaryReaderQuotas.Max);
-            var bodyBytes = (byte[])Deserializer.ReadObject(reader)!;
+            var bodyBytes = (byte[])Serialization.Deserializer.ReadObject(reader)!;
             return new BinaryData(bodyBytes);
         }
     }
 
-    static readonly DataContractSerializer Deserializer = new(typeof(byte[]));
+    // To workaround a bug in extension blocks that would otherwise classify the field as not used.
+    static class Serialization
+    {
+        public static readonly DataContractSerializer Deserializer = new(typeof(byte[]));
+    }
 }


### PR DESCRIPTION
This exposes the DLQ Reason as the "ExceptionType" and DLQ Description as "Message" to better align with assumptions in ServiceControl. This also exposes the MessageId, Header and Body extraction to allow the function package to reused the same logic.