### PR TITLE
Preserve native `ServiceBusException` when publishing to a missing topic

### DIFF
--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -182,7 +182,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                     [],
                     DispatchConsistency.Default);
 
-            Assert.That(async () => await dispatcher.Dispatch(new TransportOperations(operation1, operation2), new TransportTransaction()), Throws.InvalidOperationException);
+            Assert.That(async () => await dispatcher.Dispatch(new TransportOperations(operation1, operation2), new TransportTransaction()), Throws.Exception.InstanceOf<ServiceBusException>());
         }
 
         [Test]
@@ -763,7 +763,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
 
             Assert.Multiple(() =>
             {
-                Assert.That(async () => await dispatcher.Dispatch(new TransportOperations([.. operations]), azureServiceBusTransaction.TransportTransaction), Throws.InvalidOperationException);
+                Assert.That(async () => await dispatcher.Dispatch(new TransportOperations([.. operations]), azureServiceBusTransaction.TransportTransaction), Throws.Exception.InstanceOf<ServiceBusException>());
                 Assert.That(defaultSender.BatchSentMessages, Has.Count.Zero);
                 Assert.That(defaultSender.IndividuallySentMessages, Has.Count.EqualTo(0));
             });

--- a/src/Transport/AzureServiceBusTransport.cs
+++ b/src/Transport/AzureServiceBusTransport.cs
@@ -483,7 +483,7 @@ public partial class AzureServiceBusTransport : TransportDefinition
     } = int.MaxValue;
 
     /// <summary>
-    /// Specifies whether to throw an exception when publishing to a non-existent topic
+    /// Overrides the default transport behavior on message publishing and rethrows the underlying <see cref="ServiceBusException"/> if the destination topic doesn't exist
     /// </summary>
     public bool ThrowOnMissingTopicWhenPublishing { get; set; }
 

--- a/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
+++ b/src/Transport/AzureServiceBusTransportSettingsExtensions.cs
@@ -257,7 +257,7 @@ public static partial class AzureServiceBusTransportSettingsExtensions
     }
 
     /// <summary>
-    /// Overrides the default transport behavior on message publishing and throws an <c>InvalidOperationException</c> if the destination topic doesn't exist
+    /// Overrides the default transport behavior on message publishing and rethrows the underlying <see cref="ServiceBusException"/> if the destination topic doesn't exist
     /// </summary>
     /// <param name="transportExtensions"></param>
     /// <exception cref="InvalidOperationException">When the destination topic doesn't exist</exception>

--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -340,7 +340,7 @@ class MessageDispatcher(
 
             if (throwOnMissingTopic)
             {
-                throw new InvalidOperationException($"Publishing message with message ID '{message.MessageId}' to topic {destination} failed because the destination does not exist.", e);
+                throw;
             }
         }
         catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)


### PR DESCRIPTION
This PR changes the behavior for `ThrowOnMissingTopicWhenPublishing` introduced in #1396 so that publishing to a missing topic surfaces the native `ServiceBusException` rather than wrapping it in an `InvalidOperationException`.

### Why this change

- The SDK already provides the relevant context
  - `ServiceBusException` includes the failure reason, entity path, and troubleshooting details.
  - That gives callers the most direct and actionable information.

- Wrapping hides the real failure behind an inner exception
  - A wrapper adds another layer that users must inspect.
  - In this case, the extra abstraction does not add enough value to justify losing the direct SDK error surface.

- Consistency with existing transport behavior
  - Other send paths already propagate the native `ServiceBusException`.
  - The handoff to the SDK already rethrows `ServiceBusException` for `ServiceCommunicationProblem`, and for any other reasons not explicitly handled by the catch filters.
  - Keeping `ThrowOnMissingTopicWhenPublishing` aligned with that behavior reduces surprise and avoids introducing a special-case exception type for one scenario.

- The custom message can be handled through logging
  - If we want to provide additional context, logging can do that without changing the exception type.

When `ThrowOnMissingTopicWhenPublishing` is enabled, a missing topic now follows the same error model as other Azure Service Bus send failures: the native SDK exception is allowed to bubble up.