### PR TITLE
Test Updates for .NET 11 Preview 4 - master

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "11.0.0",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.0",
+    "version": "11.0.100-preview.4.26230.115",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureServiceBus.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transport.AzureServiceBus.CommandLine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ToolCommandName>asb-transport</ToolCommandName>
     <PackAsTool>True</PackAsTool>

--- a/src/CommandLineTests/NServiceBus.Transport.AzureServiceBus.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transport.AzureServiceBus.CommandLine.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MigrationAcceptanceTests/NServiceBus.Transport.AzureServiceBus.Migration.AcceptanceTests.csproj
+++ b/src/MigrationAcceptanceTests/NServiceBus.Transport.AzureServiceBus.Migration.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
     <RootNamespace>NServiceBus.Transport.AzureServiceBus.Topic.AcceptanceTests</RootNamespace>

--- a/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureServiceBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Description>Azure Service Bus transport for NServiceBus</Description>

--- a/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureServiceBus.TransportTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Set test project target frameworks (not including .NET Framework) to `net11.0`
* Updated .NET SDK in global.json to `11.0.0`