### PR TITLE
Use asynchronous wait for process exit in CommandLineTests (#1444)

### DIFF
--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -1296,7 +1296,7 @@
             process.Start();
             var outputTask = process.StandardOutput.ReadToEndAsync();
             var errorTask = process.StandardError.ReadToEndAsync();
-            process.WaitForExit(10000);
+            await process.WaitForExitAsync();
 
             var output = await outputTask;
             var error = await errorTask;


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1444