### PR TITLE
Trimming too long properties

### DIFF
--- a/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
+++ b/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
@@ -9,6 +9,9 @@ using NUnit.Framework;
 
 public class When_sending_a_message_with_long_properties : NServiceBusAcceptanceTest
 {
+    const int MaxPropertySize = 32767;
+    static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
+
     [Test]
     public async Task Should_trim_properties_before_sending()
     {
@@ -16,9 +19,9 @@ public class When_sending_a_message_with_long_properties : NServiceBusAcceptance
         {
             var options = new SendOptions();
             options.RouteToThisEndpoint();
-            foreach (var header in OutgoingMessageExtensions.HeadersToTrim)
+            foreach (var header in HeadersToTrim)
             {
-                options.SetHeader(header, new string('x', OutgoingMessageExtensions.MaxPropertySize * 2));
+                options.SetHeader(header, new string('x', MaxPropertySize * 2));
             }
 
             return options;

--- a/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
+++ b/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
@@ -50,14 +50,14 @@ public class When_sending_a_message_with_long_properties : NServiceBusAcceptance
     public class Sender : EndpointConfigurationBuilder
     {
         public Sender() =>
-            EndpointSetup<DefaultServer>(c  => c.LimitMessageProcessingConcurrencyTo(1));
+            EndpointSetup<DefaultServer>(c => c.LimitMessageProcessingConcurrencyTo(1));
 
         [Handler]
         public class MyMessageHandler(Context testContext) : IHandleMessages<MyMessage>
         {
             public Task Handle(MyMessage message, IMessageHandlerContext context)
             {
-                testContext.ReceivedCount ++;
+                testContext.ReceivedCount++;
                 testContext.MarkAsCompleted(testContext.ReceivedCount == 2);
                 return Task.CompletedTask;
             }

--- a/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
+++ b/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
@@ -1,0 +1,68 @@
+namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Sending;
+
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using Logging;
+using NServiceBus.AcceptanceTests;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NUnit.Framework;
+
+public class When_sending_a_message_with_long_properties : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_trim_properties_before_sending()
+    {
+        static SendOptions CreateOptions()
+        {
+            var options = new SendOptions();
+            options.RouteToThisEndpoint();
+            foreach (var header in OutgoingMessageExtensions.HeadersToTrim)
+            {
+                options.SetHeader(header, new string('x', OutgoingMessageExtensions.MaxPropertySize * 2));
+            }
+
+            return options;
+        }
+
+        var context = await Scenario.Define<Context>(c =>
+            {
+                c.LogLevel = LogLevel.Debug;
+            })
+            .WithEndpoint<Sender>(b => b.When(async session =>
+            {
+                var options = CreateOptions();
+                options.RequireImmediateDispatch();
+                await session.Send(new MyMessage(), options);
+
+                await session.Send(new MyMessage(), CreateOptions());
+            }))
+            .Run();
+
+        Assert.That(context.ReceivedCount, Is.EqualTo(2), "Message was not received");
+    }
+
+
+    public class Context : ScenarioContext
+    {
+        public int ReceivedCount { get; set; }
+    }
+
+    public class Sender : EndpointConfigurationBuilder
+    {
+        public Sender() =>
+            EndpointSetup<DefaultServer>(c  => c.LimitMessageProcessingConcurrencyTo(1));
+
+        [Handler]
+        public class MyMessageHandler(Context testContext) : IHandleMessages<MyMessage>
+        {
+            public Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                testContext.ReceivedCount ++;
+                testContext.MarkAsCompleted(testContext.ReceivedCount == 2);
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class MyMessage : ICommand;
+}

--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Transactions;
 using Azure.Messaging.ServiceBus;
@@ -1474,6 +1475,42 @@ public class MessageDispatcherTests
             Assert.That(message.ApplicationProperties, Contains.Key(typeof(ISomeEventInterface).FullName));
             Assert.That(message.ApplicationProperties.ContainsKey(proxyType), Is.False);
             Assert.That(message.ApplicationProperties.ContainsKey(typeof(ISomeEventInterface).AssemblyQualifiedName), Is.False);
+        }
+    }
+
+    [Test]
+    public async Task Should_trim_too_long_properties_for_isolated_messages()
+    {
+        var client = new FakeServiceBusClient();
+
+        var dispatcher = CreateDispatcher(client, TopicTopology.FromOptions(new TopologyOptions()));
+
+        var operation1 =
+            new TransportOperation(new OutgoingMessage("SomeId",
+                    OutgoingMessageExtensions.HeadersToTrim
+                        .ToDictionary(
+                            header => header, 
+                            header => new string('x', OutgoingMessageExtensions.MaxPropertySize * 2)
+                        ),
+                    ReadOnlyMemory<byte>.Empty),
+                new UnicastAddressTag("SomeDestination"),
+                [],
+                DispatchConsistency.Isolated);
+
+        await dispatcher.Dispatch(new TransportOperations(operation1), new TransportTransaction());
+
+        var sender = client.Senders["SomeDestination"];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sender.IndividuallySentMessages, Has.Count.EqualTo(1));
+            Assert.That(sender.BatchSentMessages, Is.Empty);
+
+            var sentMessage = sender.IndividuallySentMessages.First();
+            foreach (var header in OutgoingMessageExtensions.HeadersToTrim)
+            {
+                Assert.That(Encoding.UTF8.GetByteCount(sentMessage.ApplicationProperties[header]!.ToString()!), Is.LessThan(OutgoingMessageExtensions.MaxPropertySize));
+            }
         }
     }
 }

--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -1492,7 +1492,7 @@ public class MessageDispatcherTests
             new TransportOperation(new OutgoingMessage("SomeId",
                     HeadersToTrim
                         .ToDictionary(
-                            header => header, _ => new string('x', MaxPropertySize * 2)
+                            header => header, _ => new string('€', MaxPropertySize * 2)
                         ),
                     ReadOnlyMemory<byte>.Empty),
                 new UnicastAddressTag("SomeDestination"),

--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -1489,8 +1489,7 @@ public class MessageDispatcherTests
             new TransportOperation(new OutgoingMessage("SomeId",
                     OutgoingMessageExtensions.HeadersToTrim
                         .ToDictionary(
-                            header => header, 
-                            header => new string('x', OutgoingMessageExtensions.MaxPropertySize * 2)
+                            header => header, _ => new string('x', OutgoingMessageExtensions.MaxPropertySize * 2)
                         ),
                     ReadOnlyMemory<byte>.Empty),
                 new UnicastAddressTag("SomeDestination"),

--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -14,6 +14,9 @@ using Routing;
 [TestFixture]
 public class MessageDispatcherTests
 {
+    const int MaxPropertySize = 32767;
+    static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
+
     static MessageDispatcher CreateDispatcher(
         ServiceBusClient client,
         TopicTopology topology,
@@ -1487,9 +1490,9 @@ public class MessageDispatcherTests
 
         var operation1 =
             new TransportOperation(new OutgoingMessage("SomeId",
-                    OutgoingMessageExtensions.HeadersToTrim
+                    HeadersToTrim
                         .ToDictionary(
-                            header => header, _ => new string('x', OutgoingMessageExtensions.MaxPropertySize * 2)
+                            header => header, _ => new string('x', MaxPropertySize * 2)
                         ),
                     ReadOnlyMemory<byte>.Empty),
                 new UnicastAddressTag("SomeDestination"),
@@ -1506,9 +1509,9 @@ public class MessageDispatcherTests
             Assert.That(sender.BatchSentMessages, Is.Empty);
 
             var sentMessage = sender.IndividuallySentMessages.First();
-            foreach (var header in OutgoingMessageExtensions.HeadersToTrim)
+            foreach (var header in HeadersToTrim)
             {
-                Assert.That(Encoding.UTF8.GetByteCount(sentMessage.ApplicationProperties[header]!.ToString()!), Is.LessThan(OutgoingMessageExtensions.MaxPropertySize));
+                Assert.That(Encoding.UTF8.GetByteCount(sentMessage.ApplicationProperties[header]!.ToString()!), Is.LessThan(MaxPropertySize));
             }
         }
     }

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -8,7 +8,8 @@ using Azure.Messaging.ServiceBus;
 static class OutgoingMessageExtensions
 {
     // The actual property size limit is 32767 but the total size of all properties must be at most 65534.
-    // We use buffer to avoid hitting the limit
+    // Based on https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas
+    // We also use some buffer to avoid hitting the limit
     const int MaxPropertySize = 32767;
     const int Buffer = 2048;
     static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -91,27 +91,28 @@ static class OutgoingMessageExtensions
         }
     }
 
-static void TrimTooLongKnownHeadersInPlace(ServiceBusMessage message)
-{
-    var maxUtf8Bytes = MaxPropertySize - Buffer;
-
-    Encoder? encoder = null;
-    byte[]? trimBuffer = null;
-
-    foreach (var headerName in HeadersToTrim)
+    static void TrimTooLongKnownHeadersInPlace(ServiceBusMessage message)
     {
-        if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
-            headerValue is not string value ||
-            Encoding.UTF8.GetByteCount(value) <= maxUtf8Bytes)
+        var maxUtf8Bytes = MaxPropertySize - Buffer;
+
+        Encoder? encoder = null;
+        byte[]? trimBuffer = null;
+
+        foreach (var headerName in HeadersToTrim)
         {
-            continue;
+            if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
+                headerValue is not string value ||
+                Encoding.UTF8.GetByteCount(value) <= maxUtf8Bytes)
+            {
+                continue;
+            }
+
+            encoder ??= Encoding.UTF8.GetEncoder();
+            trimBuffer ??= new byte[maxUtf8Bytes];
+
+            encoder.Reset();
+            encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
+            message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
         }
-
-        encoder ??= Encoding.UTF8.GetEncoder();
-        trimBuffer ??= new byte[maxUtf8Bytes];
-
-        encoder.Reset();
-        encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
-        message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
     }
 }

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 
@@ -94,34 +93,21 @@ static class OutgoingMessageExtensions
 
     static void TrimTooLongKnownHeadersInPlace(ServiceBusMessage message)
     {
-        foreach (var headerNamer in HeadersToTrim)
+        var encoder = Encoding.UTF8.GetEncoder();
+        var trimBuffer = new byte[MaxPropertySize - Buffer];
+
+        foreach (var headerName in HeadersToTrim)
         {
-            message.ApplicationProperties.TryGetValue(headerNamer, out var headerValue);
+            message.ApplicationProperties.TryGetValue(headerName, out var headerValue);
 
             if (headerValue is not string value || Encoding.UTF8.GetByteCount(value) <= MaxPropertySize)
             {
                 continue;
             }
 
-            var sb = new StringBuilder(value.Length);
-            int usedBytes = 0;
-
-            var enumerator = StringInfo.GetTextElementEnumerator(value);
-            while (enumerator.MoveNext())
-            {
-                string element = (string)enumerator.Current;
-                int elementBytes = Encoding.UTF8.GetByteCount(element);
-
-                if (usedBytes + elementBytes + Buffer > MaxPropertySize)
-                {
-                    break;
-                }
-
-                sb.Append(element);
-                usedBytes += elementBytes;
-            }
-
-            message.ApplicationProperties[headerNamer] = sb.ToString();
+            encoder.Reset();
+            encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
+            message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
         }
     }
 }

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -2,10 +2,18 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using Azure.Messaging.ServiceBus;
 
 static class OutgoingMessageExtensions
 {
+    // The actual property size limit is 32767 but the total size of all properties must be at most 65534.
+    // We use buffer to avoid hitting the limit
+    internal const int MaxPropertySize = 32767;
+    const int Buffer = 2048;
+    internal static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
+
     public static ServiceBusMessage ToAzureServiceBusMessage(
         this IOutgoingTransportOperation outgoingTransportOperation,
         string? incomingQueuePartitionKey
@@ -28,6 +36,8 @@ static class OutgoingMessageExtensions
         SetReplyToAddress(message, outgoingMessage.Headers);
 
         CopyHeaders(message, outgoingMessage.Headers);
+
+        TrimTooLongKnownHeadersInPlace(message);
 
         return message;
     }
@@ -79,6 +89,39 @@ static class OutgoingMessageExtensions
         foreach (var header in headers)
         {
             outgoingMessage.ApplicationProperties[header.Key] = header.Value;
+        }
+    }
+
+    static void TrimTooLongKnownHeadersInPlace(ServiceBusMessage message)
+    {
+        foreach (var headerNamer in HeadersToTrim)
+        {
+            message.ApplicationProperties.TryGetValue(headerNamer, out var headerValue);
+
+            if (headerValue is not string value || Encoding.UTF8.GetByteCount(value) <= MaxPropertySize)
+            {
+                continue;
+            }
+
+            var sb = new StringBuilder(value.Length);
+            int usedBytes = 0;
+
+            var enumerator = StringInfo.GetTextElementEnumerator(value);
+            while (enumerator.MoveNext())
+            {
+                string element = (string)enumerator.Current;
+                int elementBytes = Encoding.UTF8.GetByteCount(element);
+
+                if (usedBytes + elementBytes + Buffer > MaxPropertySize)
+                {
+                    break;
+                }
+
+                sb.Append(element);
+                usedBytes += elementBytes;
+            }
+
+            message.ApplicationProperties[headerNamer] = sb.ToString();
         }
     }
 }

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -9,9 +9,9 @@ static class OutgoingMessageExtensions
 {
     // The actual property size limit is 32767 but the total size of all properties must be at most 65534.
     // We use buffer to avoid hitting the limit
-    internal const int MaxPropertySize = 32767;
+    const int MaxPropertySize = 32767;
     const int Buffer = 2048;
-    internal static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
+    static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
 
     public static ServiceBusMessage ToAzureServiceBusMessage(
         this IOutgoingTransportOperation outgoingTransportOperation,

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -91,23 +91,27 @@ static class OutgoingMessageExtensions
         }
     }
 
-    static void TrimTooLongKnownHeadersInPlace(ServiceBusMessage message)
+static void TrimTooLongKnownHeadersInPlace(ServiceBusMessage message)
+{
+    var maxUtf8Bytes = MaxPropertySize - Buffer;
+
+    Encoder? encoder = null;
+    byte[]? trimBuffer = null;
+
+    foreach (var headerName in HeadersToTrim)
     {
-        var encoder = Encoding.UTF8.GetEncoder();
-        var trimBuffer = new byte[MaxPropertySize - Buffer];
-
-        foreach (var headerName in HeadersToTrim)
+        if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
+            headerValue is not string value ||
+            Encoding.UTF8.GetByteCount(value) <= maxUtf8Bytes)
         {
-            message.ApplicationProperties.TryGetValue(headerName, out var headerValue);
-
-            if (headerValue is not string value || Encoding.UTF8.GetByteCount(value) <= MaxPropertySize)
-            {
-                continue;
-            }
-
-            encoder.Reset();
-            encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
-            message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
+            continue;
         }
+
+        encoder ??= Encoding.UTF8.GetEncoder();
+        trimBuffer ??= new byte[maxUtf8Bytes];
+
+        encoder.Reset();
+        encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
+        message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
     }
 }


### PR DESCRIPTION
Fix for https://github.com/Particular/NServiceBus/issues/5764

Trimming too long properties that would lead to failure when sending a message.