### PR TITLE
Endpoint in endless loop when stacktrace is too long

### DIFF
--- a/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
+++ b/src/AcceptanceTests/Sending/When_sending_a_message_with_long_properties.cs
@@ -1,0 +1,70 @@
+namespace NServiceBus.Transport.AzureServiceBus.AcceptanceTests.Sending;
+
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using Logging;
+using NServiceBus.AcceptanceTests;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NUnit.Framework;
+
+public class When_sending_a_message_with_long_properties : NServiceBusAcceptanceTest
+{
+    const int MaxPropertySize = 32767;
+    static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
+
+    [Test]
+    public async Task Should_trim_properties_before_sending()
+    {
+        static SendOptions CreateOptions()
+        {
+            var options = new SendOptions();
+            options.RouteToThisEndpoint();
+            foreach (var header in HeadersToTrim)
+            {
+                options.SetHeader(header, new string('x', MaxPropertySize * 2));
+            }
+
+            return options;
+        }
+
+        var context = await Scenario.Define<Context>(c =>
+            {
+                c.LogLevel = LogLevel.Debug;
+            })
+            .WithEndpoint<Sender>(b => b.When(async session =>
+            {
+                var options = CreateOptions();
+                options.RequireImmediateDispatch();
+                await session.Send(new MyMessage(), options);
+
+                await session.Send(new MyMessage(), CreateOptions());
+            }))
+            .Done(c => c.ReceivedCount == 2)
+            .Run();
+
+        Assert.That(context.ReceivedCount, Is.EqualTo(2), "Message was not received");
+    }
+
+
+    public class Context : ScenarioContext
+    {
+        public int ReceivedCount { get; set; }
+    }
+
+    public class Sender : EndpointConfigurationBuilder
+    {
+        public Sender() =>
+            EndpointSetup<DefaultServer>(c => c.LimitMessageProcessingConcurrencyTo(1));
+
+        public class MyMessageHandler(Context testContext) : IHandleMessages<MyMessage>
+        {
+            public Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                testContext.ReceivedCount++;
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class MyMessage : ICommand;
+}

--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using System.Threading.Tasks;
     using System.Transactions;
     using Azure.Messaging.ServiceBus;
@@ -12,6 +13,9 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
     [TestFixture]
     public class MessageDispatcherTests
     {
+        const int MaxPropertySize = 32767;
+        static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
+
         [Test]
         public async Task Should_dispatch_unicast_isolated_dispatches_individually()
         {
@@ -734,6 +738,41 @@ namespace NServiceBus.Transport.AzureServiceBus.Tests.Sending
                     .Matches<ServiceBusMessage>(msg => msg.TransactionPartitionKey == null));
                 Assert.That(transactionalSender.BatchSentMessages, Is.Empty);
                 Assert.That(azureServiceBusTransaction.Transaction, Is.Null);
+            });
+        }
+
+        [Test]
+        public async Task Should_trim_too_long_properties_for_isolated_messages()
+        {
+            var client = new FakeServiceBusClient();
+
+            var dispatcher = new MessageDispatcher(client, new MessageSenderRegistry(), TopicTopology.FromOptions(new TopologyOptions()));
+
+            var operation1 =
+                new TransportOperation(new OutgoingMessage("SomeId",
+                        HeadersToTrim
+                            .ToDictionary(
+                                header => header, _ => new string('€', MaxPropertySize * 2)
+                            ),
+                        ReadOnlyMemory<byte>.Empty),
+                    new UnicastAddressTag("SomeDestination"),
+                    [],
+                    DispatchConsistency.Isolated);
+
+            await dispatcher.Dispatch(new TransportOperations(operation1), new TransportTransaction());
+
+            var sender = client.Senders["SomeDestination"];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sender.IndividuallySentMessages, Has.Count.EqualTo(1));
+                Assert.That(sender.BatchSentMessages, Is.Empty);
+
+                var sentMessage = sender.IndividuallySentMessages.First();
+                foreach (var header in HeadersToTrim)
+                {
+                    Assert.That(Encoding.UTF8.GetByteCount(sentMessage.ApplicationProperties[header]!.ToString()!), Is.LessThan(MaxPropertySize));
+                }
             });
         }
 

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -2,11 +2,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Azure.Messaging.ServiceBus;
 using Configuration;
 
 static class OutgoingMessageExtensions
 {
+    // The actual property size limit is 32767 but the total size of all properties must be at most 65534.
+    // Based on https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas
+    // We also use some buffer to avoid hitting the limit
+    const int MaxPropertySize = 32767;
+    const int Buffer = 2048;
+    static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
+
     public static ServiceBusMessage ToAzureServiceBusMessage(
         this IOutgoingTransportOperation outgoingTransportOperation,
         string? incomingQueuePartitionKey,
@@ -37,6 +45,8 @@ static class OutgoingMessageExtensions
         SetReplyToAddress(message, outgoingMessage.Headers);
 
         CopyHeaders(message, outgoingMessage.Headers);
+
+        TrimTooLongKnownHeadersInPlace(message);
 
         return message;
     }
@@ -88,6 +98,31 @@ static class OutgoingMessageExtensions
         foreach (var header in headers)
         {
             outgoingMessage.ApplicationProperties[header.Key] = header.Value;
+        }
+    }
+
+    static void TrimTooLongKnownHeadersInPlace(ServiceBusMessage message)
+    {
+        var maxUtf8Bytes = MaxPropertySize - Buffer;
+
+        Encoder? encoder = null;
+        byte[]? trimBuffer = null;
+
+        foreach (var headerName in HeadersToTrim)
+        {
+            if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
+                headerValue is not string value ||
+                Encoding.UTF8.GetByteCount(value) <= maxUtf8Bytes)
+            {
+                continue;
+            }
+
+            encoder ??= Encoding.UTF8.GetEncoder();
+            trimBuffer ??= new byte[maxUtf8Bytes];
+
+            encoder.Reset();
+            encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
+            message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
         }
     }
 }


### PR DESCRIPTION
Backport of:
-  #1457 

Which fixes for the `release-5.1` branch:
- #1460 