### PR TITLE
Messages dispatched outside a batch are wrapping the ServiceBus exception

### DIFF
--- a/src/Transport/Sending/MessageDispatcher.cs
+++ b/src/Transport/Sending/MessageDispatcher.cs
@@ -253,7 +253,7 @@ class MessageDispatcher(
 
                 if (throwOnMissingTopic)
                 {
-                    throw new InvalidOperationException($"Publishing messages to topic {destination} failed because the destination does not exist.", e);
+                    throw;
                 }
 
                 return;


### PR DESCRIPTION
### Symptoms

Messages dispatched outside a batch are still wrapping the ServiceBus exception.

### Who's affected

Anyone using ASB transport 6.3.* and 6.4*

### Root cause

As part of the work done to [add a new ThrowOnMissingTopicWhenPublishing transport configuration property](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1396), the behavior for `ThrowOnMissingTopicWhenPublishing` was [changed so that publishing to a missing topic surfaces the native ServiceBusException rather than wrapping it in an InvalidOperationException](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1405).

This PR fixes a missed exception that was still being wrapped.

### Confirmed workarounds

None

### Backported to:

- [6.4](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1487)
- [6.3](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1488)