### PR TITLE
Optimize header trimming

### DIFF
--- a/src/Tests/Sending/MessageDispatcherTests.cs
+++ b/src/Tests/Sending/MessageDispatcherTests.cs
@@ -15,6 +15,7 @@ using Routing;
 public class MessageDispatcherTests
 {
     const int MaxPropertySize = 32767;
+    const int Buffer = 2048;
     static readonly string[] HeadersToTrim = ["NServiceBus.ExceptionInfo.StackTrace", "NServiceBus.ExceptionInfo.Message"];
 
     static MessageDispatcher CreateDispatcher(
@@ -1539,6 +1540,175 @@ public class MessageDispatcherTests
         foreach (var header in HeadersToTrim)
         {
             Assert.That(Encoding.UTF8.GetByteCount(sentMessage.ApplicationProperties[header]!.ToString()!), Is.LessThan(MaxPropertySize));
+        }
+    }
+
+    [Test]
+    public async Task Should_not_trim_multibyte_values_that_fit_the_budget()
+    {
+        var client = new FakeServiceBusClient();
+
+        var dispatcher = CreateDispatcher(client, TopicTopology.FromOptions(new TopologyOptions()));
+
+        // (MaxPropertySize - Buffer) / 3 chars of '€' is (MaxPropertySize - Buffer) - 2 bytes and fits the budget without trimming
+        var value = new string('€', (MaxPropertySize - Buffer) / 3);
+
+        var operation1 =
+            new TransportOperation(new OutgoingMessage("SomeId",
+                    HeadersToTrim
+                        .ToDictionary(
+                            header => header, _ => value
+                        ),
+                    ReadOnlyMemory<byte>.Empty),
+                new UnicastAddressTag("SomeDestination"),
+                [],
+                DispatchConsistency.Isolated);
+
+        await dispatcher.Dispatch(new TransportOperations(operation1), new TransportTransaction());
+
+        var sender = client.Senders["SomeDestination"];
+
+        var batchContent = sender[sender.BatchSentMessages.ElementAt(0)];
+        var sentMessage = batchContent.ElementAt(0);
+        foreach (var header in HeadersToTrim)
+        {
+            Assert.That(sentMessage.ApplicationProperties[header]!.ToString(), Is.EqualTo(value));
+        }
+    }
+
+    [Test]
+    public async Task Should_trim_multibyte_values_that_just_exceed_the_budget()
+    {
+        var client = new FakeServiceBusClient();
+
+        var dispatcher = CreateDispatcher(client, TopicTopology.FromOptions(new TopologyOptions()));
+
+        // one '€' char (three bytes) more than the budget allows, trimming must cut the last char without corrupting the remaining ones
+        var value = new string('€', ((MaxPropertySize - Buffer) / 3) + 1);
+
+        var operation1 =
+            new TransportOperation(new OutgoingMessage("SomeId",
+                    HeadersToTrim
+                        .ToDictionary(
+                            header => header, _ => value
+                        ),
+                    ReadOnlyMemory<byte>.Empty),
+                new UnicastAddressTag("SomeDestination"),
+                [],
+                DispatchConsistency.Isolated);
+
+        await dispatcher.Dispatch(new TransportOperations(operation1), new TransportTransaction());
+
+        var sender = client.Senders["SomeDestination"];
+
+        var batchContent = sender[sender.BatchSentMessages.ElementAt(0)];
+        var sentMessage = batchContent.ElementAt(0);
+        foreach (var header in HeadersToTrim)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Encoding.UTF8.GetByteCount(sentMessage.ApplicationProperties[header]!.ToString()!), Is.LessThanOrEqualTo(MaxPropertySize - Buffer));
+                Assert.That(sentMessage.ApplicationProperties[header]!.ToString(), Is.EqualTo(value[..^1]));
+            }
+        }
+    }
+
+    [Test]
+    public async Task Should_not_trim_value_that_exactly_fits_the_budget()
+    {
+        var client = new FakeServiceBusClient();
+
+        var dispatcher = CreateDispatcher(client, TopicTopology.FromOptions(new TopologyOptions()));
+
+        // 10239 three-byte chars plus two ASCII chars are exactly (MaxPropertySize - Buffer) UTF-8 bytes and must pass through the conversion unchanged
+        var value = new string('€', (MaxPropertySize - Buffer) / 3) + "aa";
+
+        var operation1 =
+            new TransportOperation(new OutgoingMessage("SomeId",
+                    HeadersToTrim
+                        .ToDictionary(
+                            header => header, _ => value
+                        ),
+                    ReadOnlyMemory<byte>.Empty),
+                new UnicastAddressTag("SomeDestination"),
+                [],
+                DispatchConsistency.Isolated);
+
+        await dispatcher.Dispatch(new TransportOperations(operation1), new TransportTransaction());
+
+        var sender = client.Senders["SomeDestination"];
+
+        var batchContent = sender[sender.BatchSentMessages.ElementAt(0)];
+        var sentMessage = batchContent.ElementAt(0);
+        foreach (var header in HeadersToTrim)
+        {
+            Assert.That(sentMessage.ApplicationProperties[header]!.ToString(), Is.EqualTo(value));
+        }
+    }
+
+    [Test]
+    public async Task Should_trim_value_with_unpaired_surrogate_at_the_cut_point()
+    {
+        var client = new FakeServiceBusClient();
+
+        var dispatcher = CreateDispatcher(client, TopicTopology.FromOptions(new TopologyOptions()));
+
+        // the trailing unpaired high surrogate is flushed as U+FFFD which no longer fits the budget, so trimming must drop it without corrupting the preceding chars
+        var value = new string('€', (MaxPropertySize - Buffer) / 3) + "\uD800";
+
+        var operation1 =
+            new TransportOperation(new OutgoingMessage("SomeId",
+                    HeadersToTrim
+                        .ToDictionary(
+                            header => header, _ => value
+                        ),
+                    ReadOnlyMemory<byte>.Empty),
+                new UnicastAddressTag("SomeDestination"),
+                [],
+                DispatchConsistency.Isolated);
+
+        await dispatcher.Dispatch(new TransportOperations(operation1), new TransportTransaction());
+
+        var sender = client.Senders["SomeDestination"];
+
+        var batchContent = sender[sender.BatchSentMessages.ElementAt(0)];
+        var sentMessage = batchContent.ElementAt(0);
+        foreach (var header in HeadersToTrim)
+        {
+            Assert.That(sentMessage.ApplicationProperties[header]!.ToString(), Is.EqualTo(value[..^1]));
+        }
+    }
+
+    [Test]
+    public async Task Should_not_trim_long_ascii_values_that_pass_the_prescan()
+    {
+        var client = new FakeServiceBusClient();
+
+        var dispatcher = CreateDispatcher(client, TopicTopology.FromOptions(new TopologyOptions()));
+
+        // long enough to pass the cheap prescan but comfortably within the byte budget when counted as UTF-8
+        var value = new string('a', ((MaxPropertySize - Buffer) / 3) + 1);
+
+        var operation1 =
+            new TransportOperation(new OutgoingMessage("SomeId",
+                    HeadersToTrim
+                        .ToDictionary(
+                            header => header, _ => value
+                        ),
+                    ReadOnlyMemory<byte>.Empty),
+                new UnicastAddressTag("SomeDestination"),
+                [],
+                DispatchConsistency.Isolated);
+
+        await dispatcher.Dispatch(new TransportOperations(operation1), new TransportTransaction());
+
+        var sender = client.Senders["SomeDestination"];
+
+        var batchContent = sender[sender.BatchSentMessages.ElementAt(0)];
+        var sentMessage = batchContent.ElementAt(0);
+        foreach (var header in HeadersToTrim)
+        {
+            Assert.That(sentMessage.ApplicationProperties[header]!.ToString(), Is.EqualTo(value));
         }
     }
 }

--- a/src/Transport/Sending/OutgoingMessageExtensions.cs
+++ b/src/Transport/Sending/OutgoingMessageExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureServiceBus;
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
 using Azure.Messaging.ServiceBus;
@@ -99,21 +100,39 @@ static class OutgoingMessageExtensions
         Encoder? encoder = null;
         byte[]? trimBuffer = null;
 
-        foreach (var headerName in HeadersToTrim)
+        try
         {
-            if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
-                headerValue is not string value ||
-                Encoding.UTF8.GetByteCount(value) <= maxUtf8Bytes)
+            foreach (var headerName in HeadersToTrim)
             {
-                continue;
+                // Each UTF-16 code unit contributes at most three UTF-8 bytes; a valid surrogate pair contributes four bytes across two code units.
+                // This cheap prescan avoids scanning and counting the bytes of values that are certainly short enough.
+                if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
+                    headerValue is not string value ||
+                    value.Length <= maxUtf8Bytes / 3)
+                {
+                    continue;
+                }
+
+                trimBuffer ??= ArrayPool<byte>.Shared.Rent(maxUtf8Bytes);
+                encoder ??= Encoding.UTF8.GetEncoder();
+
+                encoder.Reset();
+                encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(0, maxUtf8Bytes), flush: true, out _, out int bytesUsed, out bool completed);
+
+                if (!completed)
+                {
+                    message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
+                }
             }
-
-            encoder ??= Encoding.UTF8.GetEncoder();
-            trimBuffer ??= new byte[maxUtf8Bytes];
-
-            encoder.Reset();
-            encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
-            message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
+        }
+        finally
+        {
+            if (trimBuffer is not null)
+            {
+                // The buffer contains header values that can hold sensitive information (stack traces, exception messages)
+                // and the shared pool hands it to unrelated future renters, so it must be cleared before returning it.
+                ArrayPool<byte>.Shared.Return(trimBuffer, clearArray: true);
+            }
         }
     }
 }


### PR DESCRIPTION
Follow up on https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/1457

## What this changes

`TrimTooLongKnownHeadersInPlace` now:

- skips the byte count entirely for values that cannot possibly exceed the budget (`value.Length <= maxUtf8Bytes / 3`, since a UTF-16 code unit maps to at most three UTF-8 bytes)
- converts directly into the trim buffer and uses the `completed` flag to detect overflow instead of counting the bytes first (`flush: true`, so a value that fits but ends with an unpaired high surrogate is flushed as U+FFFD instead of being reported as incomplete)
- rents the trim buffer from the shared array pool and clears it before returning it. Stack traces and exception messages can contain sensitive data, and a pooled array outlives the trimmed strings and is handed to unrelated code later, so clearing felt like cheap insurance

## Why I think this is worth it

In the #1457 review we were unsure whether the trimming path is hot enough to care about, since errors are rare in healthy systems. My take: isolated exceptions are rare, bursts are not. When a handler throws (a null reference, say) it fails every message in flight, up to the endpoint concurrency (the default is the processor count), and every failure dispatches an error message through this code. The trim path runs exactly when the process is already busy dealing with the failure, so it should be cheap and avoid allocations where possible.

## Numbers

Throwaway BenchmarkDotNet run (Apple Silicon Arm64, .NET 8, ShortRunJob, MemoryDiagnoser, two trimmed headers per message; both columns include a ~15 ns per-op state restore that the mutation requires):

| Header size (chars) | Before | After | Ratio | Before alloc/op | After alloc/op |
|--------------------:|--------:|------:|------:|----------------:|---------------:|
| 100, no trim        | 38.9 ns | 30.6 ns | 0.79 | 0 B | 0 B |
| 10,000, no trim, prescan applies | 359.8 ns | 31.1 ns | 0.09 | 0 B | 0 B |
| 50,000, trims       | 7.72 µs | 5.62 µs | 0.73 | 153,832 B | 123,088 B |
| 200,000, trims      | 13.03 µs | 5.72 µs | 0.44 | 153,832 B | 123,088 B |

What I take away from those numbers:

- Typical stack traces (around 10k chars) no longer pay the `GetByteCount` scan. That path is about 11.6x faster and used to be pure CPU waste on every error dispatch.
- Once trimming kicks in, the work is bounded by the 30,719-byte budget instead of the input length. At 200k chars the conversion is about 2.3x faster, and the gap grows with header size.
- The 30,719-byte `new byte[]` per trimmed message is gone. The remaining allocations are the trimmed strings themselves. The `clearArray: true` memset is included in the "after" numbers, so clearing the buffer costs nothing measurable.
- ShortRunJob on my laptop, so treat the timings as directional. The allocation numbers are exact.

<details>

## Benchmark used

```csharp
using System.Buffers;
using System.Text;
using Azure.Messaging.ServiceBus;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkRunner.Run<TrimBenchmarks>();

[ShortRunJob]
[MemoryDiagnoser]
public class TrimBenchmarks
{
    const int MaxPropertySize = 32767;
    const int Buffer = 2048;
    const string StackTraceHeader = "NServiceBus.ExceptionInfo.StackTrace";
    const string ExceptionMessageHeader = "NServiceBus.ExceptionInfo.Message";
    static readonly string[] HeadersToTrim = [StackTraceHeader, ExceptionMessageHeader];

    ServiceBusMessage message = null!;
    string stackTrace = null!;
    string exceptionMessage = null!;

    [Params(100, 10_000, 50_000, 200_000)]
    public int Size;

    [GlobalSetup]
    public void Setup()
    {
        var line = "   at MyCompany.MyApp.Handlers.OrderHandler.Handle(OrderSubmitted message, IMessageHandlerContext context) in /src/MyApp/Handlers/OrderHandler.cs:line 123";
        var sb = new StringBuilder(Size + line.Length + 1);
        while (sb.Length < Size)
        {
            sb.Append(line);
            sb.Append('\n');
        }
        stackTrace = sb.ToString()[..Size];
        exceptionMessage = new string('x', Size);
        message = new ServiceBusMessage();
        message.ApplicationProperties[StackTraceHeader] = stackTrace;
        message.ApplicationProperties[ExceptionMessageHeader] = exceptionMessage;
    }

    void Restore()
    {
        message.ApplicationProperties[StackTraceHeader] = stackTrace;
        message.ApplicationProperties[ExceptionMessageHeader] = exceptionMessage;
    }

    [Benchmark(Baseline = true, Description = "Master (GetByteCount + new byte[] + flush:false)")]
    public void Master()
    {
        Restore();
        TrimMaster(message);
    }

    [Benchmark(Description = "Branch (prescan + ArrayPool + flush:true + clear)")]
    public void Branch()
    {
        Restore();
        TrimBranch(message);
    }

    [Benchmark(Description = "Overhead (restore only)", Baseline = false)]
    public void Overhead()
    {
        Restore();
    }

    // ---- master implementation (merged PR #1457) ----

    static void TrimMaster(ServiceBusMessage message)
    {
        var maxUtf8Bytes = MaxPropertySize - Buffer;

        Encoder? encoder = null;
        byte[]? trimBuffer = null;

        foreach (var headerName in HeadersToTrim)
        {
            if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
                headerValue is not string value ||
                Encoding.UTF8.GetByteCount(value) <= maxUtf8Bytes)
            {
                continue;
            }

            encoder ??= Encoding.UTF8.GetEncoder();
            trimBuffer ??= new byte[maxUtf8Bytes];

            encoder.Reset();
            encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(), flush: false, out _, out int bytesUsed, out _);
            message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
        }
    }

    // ---- branch implementation (feature/trim-prescan-pooled-buffer, incl. clearArray: true) ----

    static void TrimBranch(ServiceBusMessage message)
    {
        var maxUtf8Bytes = MaxPropertySize - Buffer;

        Encoder? encoder = null;
        byte[]? trimBuffer = null;

        try
        {
            foreach (var headerName in HeadersToTrim)
            {
                if (!message.ApplicationProperties.TryGetValue(headerName, out var headerValue) ||
                    headerValue is not string value ||
                    value.Length <= maxUtf8Bytes / 3)
                {
                    continue;
                }

                trimBuffer ??= ArrayPool<byte>.Shared.Rent(maxUtf8Bytes);
                encoder ??= Encoding.UTF8.GetEncoder();

                encoder.Reset();
                encoder.Convert(value.AsSpan(), trimBuffer.AsSpan(0, maxUtf8Bytes), flush: true, out _, out int bytesUsed, out bool completed);

                if (!completed)
                {
                    message.ApplicationProperties[headerName] = Encoding.UTF8.GetString(trimBuffer, 0, bytesUsed);
                }
            }
        }
        finally
        {
            if (trimBuffer is not null)
            {
                ArrayPool<byte>.Shared.Return(trimBuffer, clearArray: true);
            }
        }
    }
}

```

</details>
